### PR TITLE
Fix reallocation logic

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -926,7 +926,7 @@ extension _StringGuts {
   // TODO: internal
   public // TODO(StringGuts): for testing only
   mutating func isUniqueNative() -> Bool {
-    return _isNative && _isUnique(&_storage.0)
+    return _isUnique(&_storage.0) && _isNative
   }
 
   @_versioned

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1221,8 +1221,6 @@ extension String : Equatable {
     let lhsContigOpt = lhs._unmanagedContiguous
     let rhsContigOpt = rhs._unmanagedContiguous
     if _slowPath(lhsContigOpt == nil || rhsContigOpt == nil) {
-      dump(lhsContigOpt)
-      dump(rhsContigOpt)
       return lhs._ephemeralString._compareString(rhs._ephemeralString) == 0
     }
     let result = lhsContigOpt._unsafelyUnwrappedUnchecked.equal(


### PR DESCRIPTION
The old capacity was not correctly taken into account when calculating new storage capacity for a COW copy or for a widened copy. This led to a regression in the number of reallocations.

Additionally, isUniqueNative() had a bug in which it always returned false -- apparently _isNative is not safe to call in the same boolean expression as isUnique(_:). (Weird!)

Finally, some stray debugging output was left in StringGuts that broke the SDK/objc_keypath test.

This PR fixes the following tests:

```
Swift(macosx-x86_64) :: Interpreter/SDK/objc_keypath.swift
Swift(macosx-x86_64) :: stdlib/NewStringAppending.swift
Swift(macosx-x86_64) :: stdlib/StringReallocation.swift
```

Remaining failures:
```
Swift(macosx-x86_64) :: Interpreter/string_literal.swift
Swift(macosx-x86_64) :: Interpreter/extended_grapheme_cluster_literal.swift
Swift(macosx-x86_64) :: stdlib/NewString.swift
Swift(macosx-x86_64) :: stdlib/test_runtime_function_counters.swift
Swift(macosx-x86_64) :: stdlib/test_runtime_function_counters_with_disabled_assertions.swift
Swift(macosx-x86_64) :: IRGen/vtable_multi_file.swift
Swift(macosx-x86_64) :: IRGen/struct_layout.sil
Swift(macosx-x86_64) :: IRGen/keypaths.sil
Swift(macosx-x86_64) :: IRGen/big_types_corner_cases.swift
```