### PR TITLE
Append improvements

### DIFF
--- a/benchmark/single-source/StringBuilder.swift
+++ b/benchmark/single-source/StringBuilder.swift
@@ -17,6 +17,14 @@ public let StringBuilder = [
   BenchmarkInfo(name: "StringBuilder", runFunction: run_StringBuilder, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "StringBuilderLong", runFunction: run_StringBuilderLong, tags: [.validation, .api, .String]),
   BenchmarkInfo(name: "StringUTF16Builder", runFunction: run_StringUTF16Builder, tags: [.validation, .api, .String]),
+  BenchmarkInfo(
+    name: "StringWordBuilder",
+    runFunction: run_StringWordBuilder,
+    tags: [.validation, .api, .String]),
+  BenchmarkInfo(
+    name: "StringWordBuilderReservingCapacity",
+    runFunction: run_StringWordBuilderReservingCapacity,
+    tags: [.validation, .api, .String]),
 ]
 
 @inline(never)
@@ -82,3 +90,28 @@ public func run_StringBuilderLong(_ N: Int) {
   }
 }
 
+@inline(never)
+func buildString(
+  word: String,
+  count: Int,
+  reservingCapacity: Bool
+) -> String {
+  var sb = ""
+  if reservingCapacity {
+    sb.reserveCapacity(count * word.unicodeScalars.count)
+  }
+  for _ in 0 ..< count {
+    sb += word
+  }
+  return sb
+}
+
+@inline(never)
+public func run_StringWordBuilder(_ N: Int) {
+  _ = buildString(word: "bumfuzzle", count: 50_000 * N, reservingCapacity: false)
+}
+
+@inline(never)
+public func run_StringWordBuilderReservingCapacity(_ N: Int) {
+  _ = buildString(word: "bumfuzzle", count: 50_000 * N, reservingCapacity: true)
+}

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -226,7 +226,7 @@ public struct Character :
       "Can't form a Character from a String containing more than one extended grapheme cluster")
 
     if _fastPath(s._guts.count <= 4) {
-      let b = _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>(s._core)
+      let b = _SmallUTF16(s._core)
       if _fastPath(Int64(truncatingIfNeeded: b._storage) >= 0) {
         _representation = .smallUTF16(
           Builtin.trunc_Int64_Int63(b._storage._value))
@@ -294,14 +294,16 @@ extension Character : CustomDebugStringConvertible {
 }
 
 extension Character {
+  internal typealias _SmallUTF16 = _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
-  internal var _smallUTF16 : _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>? {
+  internal var _smallUTF16 : _SmallUTF16? {
     guard case .smallUTF16(let _63bits) = _representation else { return nil }
     _onFastPath()
     let bits = UInt64(Builtin.zext_Int63_Int64(_63bits))
     let minBitWidth = type(of: bits).bitWidth - bits.leadingZeroBitCount
-    return _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>(
+    return _SmallUTF16(
       _storage: bits,
       _bitCount: UInt8(
         truncatingIfNeeded: 16 * Swift.max(1, (minBitWidth + 15) / 16))

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -935,12 +935,7 @@ extension String {
   // String append
   @_inlineable // FIXME(sil-serialize-all)
   public static func += (lhs: inout String, rhs: String) {
-    if lhs.isEmpty {
-      lhs = rhs
-    }
-    else {
-      lhs._guts.append(rhs._guts)
-    }
+    lhs._guts.append(rhs._guts)
   }
 
   /// Constructs a `String` in `resultStorage` containing the given UTF-8.

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -113,6 +113,11 @@ public protocol StringProtocol
     encodedAs targetEncoding: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
   ) rethrows -> Result
+
+  /// The entire String onto whose slice this view is a projection.
+  var _wholeString : String { get }
+  /// The range of storage offsets of this view in `_wholeString`.
+  var _encodedOffsetRange : Range<Int> { get }
 }
 
 extension StringProtocol {
@@ -142,6 +147,11 @@ internal protocol _SwiftStringView {
   //
   // FIXME: Remove once _StringGuts has append(contentsOf:).
   var _persistentContent : String { get }
+
+  /// The entire String onto whose slice this view is a projection.
+  var _wholeString : String { get }
+  /// The range of storage offsets of this view in `_wholeString`.
+  var _encodedOffsetRange : Range<Int> { get }
 }
 
 extension _SwiftStringView {
@@ -166,6 +176,16 @@ extension String : _SwiftStringView {
   @_versioned // FIXME(sil-serialize-all)
   internal var _persistentContent : String {
     return self
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var _wholeString : String {
+    return self
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var _encodedOffsetRange : Range<Int> {
+    return 0..<_guts.count
   }
 }
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -71,7 +71,7 @@ internal func _cocoaStringToContiguous(
   return buffer
 }
 
-/// Reads the entire contents of a _CocoaString into contiguous
+/// Copies the entire contents of a _CocoaString into contiguous
 /// storage of sufficient capacity.
 @_versioned // FIXME(sil-serialize-all)
 @inline(never) // Hide the CF dependency
@@ -81,6 +81,21 @@ internal func _cocoaStringReadAll(
   _swift_stdlib_CFStringGetCharacters(
     source, _swift_shims_CFRange(
       location: 0, length: _swift_stdlib_CFStringGetLength(source)), destination)
+}
+
+/// Copies a slice of a _CocoaString into contiguous storage of
+/// sufficient capacity.
+@_versioned // FIXME(sil-serialize-all)
+@inline(never) // Hide the CF dependency
+internal func _cocoaStringCopyCharacters(
+  from source: _CocoaString,
+  range: Range<Int>,
+  into destination: UnsafeMutablePointer<UTF16.CodeUnit>
+) {
+  _swift_stdlib_CFStringGetCharacters(
+    source,
+    _swift_shims_CFRange(location: range.lowerBound, length: range.count),
+    destination)
 }
 
 @_versioned // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -315,6 +315,7 @@ public final class _NSContiguousString : _SwiftNativeNSString {
   func getCharacters(
     _ buffer: UnsafeMutablePointer<UInt16>,
     range aRange: _SwiftNSRange) {
+    _precondition(aRange.location >= 0 && aRange.length >= 0)
     _precondition(aRange.location + aRange.length <= Int(_guts.count))
     let slice = _unmanagedContiguous[
       aRange.location ..< aRange.location + aRange.length]

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -289,6 +289,14 @@ public final class _NSContiguousString : _SwiftNativeNSString {
   @_inlineable // FIXME(sil-serialize-all)
   deinit {}
 
+  @_versioned
+  internal var _unmanagedContiguous: UnsafeString {
+    @inline(__always)
+    get {
+      return _guts._unmanagedContiguous._unsafelyUnwrappedUnchecked
+    }
+  }
+  
   @_versioned // FIXME(sil-serialize-all)
 	@objc
   func length() -> Int {
@@ -298,9 +306,8 @@ public final class _NSContiguousString : _SwiftNativeNSString {
   @_versioned // FIXME(sil-serialize-all)
 	@objc
   func characterAtIndex(_ index: Int) -> UInt16 {
-    let unmanaged = _guts._unmanagedContiguous._unsafelyUnwrappedUnchecked
-    defer { _fixLifetime(_guts) }
-    return unmanaged[index]
+    defer { _fixLifetime(self) }
+    return _unmanagedContiguous[index]
   }
 
   @_versioned // FIXME(sil-serialize-all)
@@ -309,20 +316,20 @@ public final class _NSContiguousString : _SwiftNativeNSString {
     _ buffer: UnsafeMutablePointer<UInt16>,
     range aRange: _SwiftNSRange) {
     _precondition(aRange.location + aRange.length <= Int(_guts.count))
-    let unmanaged = _guts._unmanagedContiguous._unsafelyUnwrappedUnchecked
-    let slice = unmanaged[aRange.location ..< aRange.location + aRange.length]
+    let slice = _unmanagedContiguous[
+      aRange.location ..< aRange.location + aRange.length]
     slice._copy(
       into: UnsafeMutableRawPointer(buffer),
       capacityEnd: UnsafeMutableRawPointer(buffer + aRange.length),
       accomodatingElementWidth: 2)
-    _fixLifetime(_guts)
+    _fixLifetime(self)
   }
 
   @_versioned // FIXME(sil-serialize-all)
   @objc
   func _fastCharacterContents() -> UnsafeMutablePointer<UInt16>? {
-    let unmanaged = _guts._unmanagedContiguous._unsafelyUnwrappedUnchecked
-    defer { _fixLifetime(_guts) }
+    let unmanaged = _unmanagedContiguous
+    defer { _fixLifetime(self) }
     guard !unmanaged.isSingleByte else { return nil }
     return UnsafeMutablePointer(mutating: unmanaged.utf16Buffer.baseAddress)
   }
@@ -333,7 +340,7 @@ public final class _NSContiguousString : _SwiftNativeNSString {
   func _fastCStringContents(
     _ nullTerminationRequired: Bool
   ) -> UnsafePointer<UInt8>? {
-    let unmanaged = _guts._unmanagedContiguous._unsafelyUnwrappedUnchecked
+    let unmanaged = _unmanagedContiguous
     defer { _fixLifetime(_guts) }
     guard !nullTerminationRequired, unmanaged.isSingleByte else { return nil }
     return unmanaged.asciiBuffer.baseAddress

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -183,6 +183,18 @@ extension String.CharacterView : _SwiftStringView {
     // _StringGuts can never be a slice.
     return String(self._guts)
   }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _wholeString : String {
+    return String(_guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _encodedOffsetRange : Range<Int> {
+    return 0..<_guts.count
+  }
 }
 
 

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -758,11 +758,7 @@ extension String.CharacterView : RangeReplaceableCollection {
   where S.Element == Character {
     if _fastPath(newElements is _SwiftStringView) {
       let v = newElements as! _SwiftStringView
-      if _fastPath(_guts.count == 0) {
-        _guts = v._persistentContent._guts
-        return
-      }
-      _guts.append(v._ephemeralContent._guts)
+      _guts.append(v._wholeString._guts, range: v._encodedOffsetRange)
       return
     }
     reserveCapacity(_guts.count + newElements.underestimatedCount)

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -744,7 +744,7 @@ extension String.CharacterView : RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func append(_ c: Character) {
     if let c0 = c._smallUTF16 {
-      _core.append(contentsOf: c0)
+      _guts.append(contentsOf: c0)
       return
     }
     _guts.append(c._largeUTF16!)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1203,9 +1203,7 @@ extension StringProtocol {
           self as? String
         )._unsafelyUnwrappedUnchecked._unmanagedContiguous
       }
-      return (
-        self as? Substring
-      )._unsafelyUnwrappedUnchecked._unmanagedContiguous
+      return (self as? Substring)?._unmanagedContiguous
     }
   }
 }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1182,8 +1182,7 @@ extension Substring {
   @_versioned
   internal
   var _unmanagedContiguous: UnsafeString? {
-    return self._wholeString._unmanagedContiguous?[
-      self.startIndex.encodedOffset..<self.endIndex.encodedOffset]
+    return self._wholeString._unmanagedContiguous?[self._encodedOffsetRange]
   }
 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1139,6 +1139,10 @@ extension _StringGuts {
   public // TODO(StringGuts): for testing only
   mutating func append(_ other: _StringGuts) {
     guard !other._isEmpty else { return }
+    if _isEmpty && capacity == 0 { // Don't discard reserved capacity, if any
+      self = other
+      return
+    }
 
     // TODO: Eventual small form check on self and other. We could even do this
     // now for the tagged cocoa strings.

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1050,13 +1050,10 @@ extension _StringGuts {
     return nil
   }
 
-  // TODO(perf): guarantee this is a simple bitmask operation, and probably
-  // make inlineable or inline allways
   @_versioned
   internal
   var _isOpaque: Bool {
-      @inline(never) // TODO(perf): to inspect code quality
-      get { return _unmanagedContiguous == nil }
+    return _unmanagedContiguous == nil
   }
 
   @_versioned

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -267,6 +267,18 @@ extension String {
     }
   }
 
+  @_inlineable // FIXME(sil-serialize-all)
+  public mutating func append(contentsOf newElements: String) {
+    _guts.append(newElements._guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public mutating func append(contentsOf newElements: Substring) {
+    _guts.append(
+      newElements._wholeString._guts,
+      range: newElements._encodedOffsetRange)
+  }
+
   /// Appends the characters in the given sequence to the string.
   ///
   /// - Parameter newElements: A sequence of characters.

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -260,8 +260,10 @@ extension String {
   /// - Parameter c: The character to append to the string.
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func append(_ c: Character) {
-    withMutableCharacters {
-      (v: inout CharacterView) in v.append(c)
+    if let small = c._smallUTF16 {
+      _guts.append(contentsOf: small)
+    } else {
+      _guts.append(c._largeUTF16!)
     }
   }
 
@@ -271,9 +273,18 @@ extension String {
   @_inlineable // FIXME(sil-serialize-all)
   public mutating func append<S : Sequence>(contentsOf newElements: S)
     where S.Iterator.Element == Character {
-    withMutableCharacters {
-      (v: inout CharacterView) in v.append(contentsOf: newElements)
+    if _fastPath(newElements is _SwiftStringView) {
+      let v = newElements as! _SwiftStringView
+      _guts.append(v._wholeString._guts, range: v._encodedOffsetRange)
+      return
     }
+    if _fastPath(newElements is Character._SmallUTF16) {
+      let v = newElements as! Character._SmallUTF16
+      
+      return
+    }
+    reserveCapacity(_guts.count + newElements.underestimatedCount)
+    for c in newElements { self.append(c) }
   }
 
   /// Replaces the text within the specified bounds with the given characters.

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -369,6 +369,18 @@ extension String.UTF16View : _SwiftStringView {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal var _persistentContent : String { return String(self._guts) }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _wholeString : String {
+    return String(_guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _encodedOffsetRange : Range<Int> {
+    return 0..<_guts.count
+  }
 }
 
 // Index conversions

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -469,7 +469,21 @@ extension String {
 extension String.UTF8View : _SwiftStringView {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal var _persistentContent : String { return String(self._guts) }
+  internal var _persistentContent : String {
+    return String(self._guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _wholeString : String {
+    return String(_guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _encodedOffsetRange : Range<Int> {
+    return 0..<_guts.count
+  }
 }
 
 extension String.UTF8View {

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -349,6 +349,18 @@ extension String.UnicodeScalarView : _SwiftStringView {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal var _persistentContent : String { return String(_guts) }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _wholeString : String {
+    return String(_guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  var _encodedOffsetRange : Range<Int> {
+    return 0..<_guts.count
+  }
 }
 
 extension String {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -335,10 +335,13 @@ extension Substring : _SwiftStringView {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  @_versioned // FIXME(sil-serialize-all)
-  internal
-  var _wholeString: String {
+  public var _wholeString: String {
     return _slice._base
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public var _encodedOffsetRange: Range<Int> {
+    return startIndex.encodedOffset..<endIndex.encodedOffset
   }
 }
 
@@ -456,6 +459,12 @@ extension Substring.${View} : BidirectionalCollection {
   @_versioned // FIXME(sil-serialize-all)
   internal var _wholeString: String {
     return String(_slice._base._guts)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal var _encodedOffsetRange: Range<Int> {
+    return startIndex.encodedOffset..<endIndex.encodedOffset
   }
 
   @_inlineable // FIXME(sil-serialize-all)


### PR DESCRIPTION
`append(contentsOf:)` is completely weaned off `_StringCore` now. I also added public overloads for `String` and `Substring` arguments, in case people accidentally call it instead of `append(_:)`.

- The new `_wholeString`/`_encodedOffsetRange` properties on `StringProtocol`/`_SwiftStringView` enable easier use of guts in generic contexts.
- Support for copying/appending arbitrary gut slices
- Support for appending individual code points to string guts
- `_persistentString` isn't used in the stdlib anymore (except as a fallback for `_ephemeralString`)
- assorted odds and ends
