### PR TITLE
Support for 32-bit platforms (with `AnyObject?` for now)

### DIFF
--- a/stdlib/public/SDK/Foundation/NSString.swift
+++ b/stdlib/public/SDK/Foundation/NSString.swift
@@ -23,8 +23,8 @@ public class NSSimpleCString {}
 public class NSConstantString {}
 
 // Called by the SwiftObject implementation.
-public func _convertStringToNSString(_ string: String) -> NSString {
-  return string._bridgeToObjectiveC()
+public func _getDescription<T>(_ x: T) -> NSString {
+  return String(reflecting: x)._bridgeToObjectiveC()
 }
 
 extension NSString : ExpressibleByStringLiteral {

--- a/stdlib/public/core/ReflectionLegacy.swift
+++ b/stdlib/public/core/ReflectionLegacy.swift
@@ -65,16 +65,6 @@ public protocol _Mirror {
   var disposition: _MirrorDisposition { get }
 }
 
-/// An entry point that can be called from C++ code to get the summary string
-/// for an arbitrary object. The memory pointed to by "out" is initialized with
-/// the summary string.
-@_inlineable // FIXME(sil-serialize-all)
-@_silgen_name("swift_getSummary")
-public // COMPILER_INTRINSIC
-func _getSummary<T>(_ out: UnsafeMutablePointer<String>, x: T) {
-  out.initialize(to: String(reflecting: x))
-}
-
 /// Produce a mirror for any value.  The runtime produces a mirror that
 /// structurally reflects values of any type.
 @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -80,8 +80,8 @@ extension _StringGuts {
   @effects(readonly)
   public
   static func _compareDeterministicUnicodeCollation(
-    _leftUnsafeStringGutsBitPattern leftBits: (UInt64, UInt64),
-    _rightUnsafeStringGutsBitPattern rightBits: (UInt64, UInt64)
+    _leftUnsafeStringGutsBitPattern leftBits: _RawBitPattern,
+    _rightUnsafeStringGutsBitPattern rightBits: _RawBitPattern
   ) -> Int {
     let left = _StringGuts(rawBits: leftBits)
     let right = _StringGuts(rawBits: rightBits)
@@ -92,9 +92,9 @@ extension _StringGuts {
   @effects(readonly)
   public
   static func _compareDeterministicUnicodeCollation(
-    _leftUnsafeStringGutsBitPattern leftBits: (UInt64, UInt64),
+    _leftUnsafeStringGutsBitPattern leftBits: _RawBitPattern,
     _ leftRange: Range<Int>,
-    _rightUnsafeStringGutsBitPattern rightBits: (UInt64, UInt64),
+    _rightUnsafeStringGutsBitPattern rightBits: _RawBitPattern,
     _ rightRange: Range<Int>
   ) -> Int {
     let left = _StringGuts(rawBits: leftBits)

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -157,8 +157,7 @@ extension _StringGuts {
   @inline(__always)
   @_inlineable
   public func _bitwiseEqualTo(_ other: _StringGuts) -> Bool {
-    return self._object.rawBits == other._object.rawBits
-      && self._otherBits == other._otherBits
+    return self.rawBits == other.rawBits
   }
 
   @_inlineable

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -80,15 +80,11 @@ extension _StringGuts {
   @effects(readonly)
   public
   static func _compareDeterministicUnicodeCollation(
-    _leftUnsafeStringGutsBitPattern leftBits: (UInt, UInt),
-    _rightUnsafeStringGutsBitPattern rightBits: (UInt, UInt)
+    _leftUnsafeStringGutsBitPattern leftBits: (UInt64, UInt64),
+    _rightUnsafeStringGutsBitPattern rightBits: (UInt64, UInt64)
   ) -> Int {
-    let left = _StringGuts(
-      object: _StringObject(rawBits: leftBits.0),
-      otherBits: leftBits.1)
-    let right = _StringGuts(
-      object: _StringObject(rawBits: rightBits.0),
-      otherBits: rightBits.1)
+    let left = _StringGuts(rawBits: leftBits)
+    let right = _StringGuts(rawBits: rightBits)
     return _compareDeterministicUnicodeCollation(
       left, 0..<left.count, to: right, 0..<right.count)
   }
@@ -96,17 +92,13 @@ extension _StringGuts {
   @effects(readonly)
   public
   static func _compareDeterministicUnicodeCollation(
-    _leftUnsafeStringGutsBitPattern leftBits: (UInt, UInt),
+    _leftUnsafeStringGutsBitPattern leftBits: (UInt64, UInt64),
     _ leftRange: Range<Int>,
-    _rightUnsafeStringGutsBitPattern rightBits: (UInt, UInt),
+    _rightUnsafeStringGutsBitPattern rightBits: (UInt64, UInt64),
     _ rightRange: Range<Int>
   ) -> Int {
-    let left = _StringGuts(
-      object: _StringObject(rawBits: leftBits.0),
-      otherBits: leftBits.1)
-    let right = _StringGuts(
-      object: _StringObject(rawBits: rightBits.0),
-      otherBits: rightBits.1)
+    let left = _StringGuts(rawBits: leftBits)
+    let right = _StringGuts(rawBits: rightBits)
     return _compareDeterministicUnicodeCollation(
       left, leftRange, to: right, rightRange)
   }
@@ -232,11 +224,9 @@ extension _StringGuts {
       return result
     }
 #endif
-    let leftBits = (left._object.rawBits, left._otherBits)
-    let rightBits = (right._object.rawBits, right._otherBits)
     return _compareDeterministicUnicodeCollation(
-      _leftUnsafeStringGutsBitPattern: leftBits, leftRange,
-      _rightUnsafeStringGutsBitPattern: rightBits, rightRange)
+      _leftUnsafeStringGutsBitPattern: left.rawBits, leftRange,
+      _rightUnsafeStringGutsBitPattern: right.rawBits, rightRange)
   }
 
   @_inlineable
@@ -259,11 +249,9 @@ extension _StringGuts {
       return result
     }
 #endif
-    let leftBits = (left._object.rawBits, left._otherBits)
-    let rightBits = (right._object.rawBits, right._otherBits)
     return _compareDeterministicUnicodeCollation(
-      _leftUnsafeStringGutsBitPattern: leftBits,
-      _rightUnsafeStringGutsBitPattern: rightBits)
+      _leftUnsafeStringGutsBitPattern: left.rawBits,
+      _rightUnsafeStringGutsBitPattern: right.rawBits)
   }
 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1195,9 +1195,10 @@ extension _StringGuts : Sequence {
       _sanityCheck(_buffer.count == 0)
       _buffer.count = Swift.min(_buffer.capacity, _endOffset - _nextOffset)
       _sanityCheck(_buffer.count > 0)
+      let guts = _guts // Make a copy to prevent overlapping access to self
       _buffer.withUnsafeMutableBufferPointer { buffer in
         let range: Range<Int> = _nextOffset ..< _nextOffset + buffer.count
-        _guts._copy(range: range, into: buffer)
+        guts._copy(range: range, into: buffer)
       }
       _nextOffset += _buffer.count
     }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -55,9 +55,11 @@ struct _StringGuts {
   }
 #endif
 
+  public typealias _RawBitPattern = (UInt64, UInt64)
+
   @_versioned
   @_inlineable
-  internal var rawBits: (UInt64, UInt64) {
+  internal var rawBits: _RawBitPattern {
     @inline(__always)
     get {
 #if arch(i386) || arch(arm)
@@ -70,7 +72,7 @@ struct _StringGuts {
     }
   }
 
-  init(rawBits: (UInt64, UInt64)) {
+  init(rawBits: _RawBitPattern) {
 #if arch(i386) || arch(arm)
     self.init(
       object: _StringObject(rawBits: rawBits.0),

--- a/stdlib/public/core/StringVariant.swift
+++ b/stdlib/public/core/StringVariant.swift
@@ -14,7 +14,6 @@
 internal protocol _StringVariant : RandomAccessCollection
 where
   Element == Unicode.UTF16.CodeUnit,
-  IndexDistance == Int,
   SubSequence == Self {
   // FIXME associatedtype Encoding : _UnicodeEncoding
   associatedtype CodeUnit : FixedWidthInteger & UnsignedInteger

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -76,7 +76,7 @@ extern "C" void swift_stringFromUTF8InRawMemory(String *out,
 
 struct String {
   // Keep the details of String's implementation opaque to the runtime.
-  const void *x, *y, *z;
+  const uint64_t x, y;
 
   /// Keep String trivial on the C++ side so we can control its instantiation.
   String() = default;
@@ -88,7 +88,8 @@ struct String {
   }
 
   /// Copy an ASCII string into a swift String on the heap.
-  explicit String(const char *ptr, size_t size) {
+  explicit String(const char *ptr, size_t size)
+    : x(0), y(0) {
     swift_stringFromUTF8InRawMemory(this, ptr, size);
   }
 

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -74,14 +74,7 @@ SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
 
 namespace swift {
 
-struct String { void *x, *y, *z; };
-
-/// Helper from the standard library for stringizing an arbitrary object.
-extern "C" SWIFT_CC(swift)
-void swift_getSummary(String *out, OpaqueValue *value, const Metadata *T);
-
-// Convert a Swift String to an NSString.
-NSString *convertStringToNSString(String *swiftString);
+NSString *getDescription(OpaqueValue *value, const Metadata *type);
 
 }
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -147,29 +147,26 @@ static SwiftObject *_allocHelper(Class cls) {
     class_getInstanceSize(cls), mask));
 }
 
-NSString *swift::convertStringToNSString(String *swiftString) {
-  // public func _convertStringToNSString(_ string: String) -> NSString
-  typedef SWIFT_CC(swift) NSString *ConversionFn(void *sx, void *sy, void *sz);
-  auto convertStringToNSString = SWIFT_LAZY_CONSTANT(
-    reinterpret_cast<ConversionFn*>(dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation24_convertStringToNSStringySo0E0CSSF)))));
-
+NSString *swift::getDescription(OpaqueValue *value, const Metadata *type) {
+  typedef SWIFT_CC(swift) NSString *GetDescriptionFn(OpaqueValue*, const Metadata*);
+  auto getDescription = SWIFT_LAZY_CONSTANT(
+    reinterpret_cast<GetDescriptionFn*>(dlsym(RTLD_DEFAULT,
+    MANGLE_AS_STRING(MANGLE_SYM(10Foundation15_getDescriptionSo8NSStringCxlF)))));
+  
   // If Foundation hasn't loaded yet, fall back to returning the static string
   // "SwiftObject". The likelihood of someone invoking -description without
   // ObjC interop is low.
-  if (!convertStringToNSString)
+  if (!getDescription) {
     return @"SwiftObject";
+  }
 
-  return convertStringToNSString(swiftString->x,
-                                 swiftString->y,
-                                 swiftString->z);
+  return [getDescription(value, type) autorelease];
 }
 
-static NSString *_getDescription(SwiftObject *obj) {
-  String tmp;
+static NSString *_getObjectDescription(SwiftObject *obj) {
   swift_retain((HeapObject*)obj);
-  swift_getSummary(&tmp, (OpaqueValue*)&obj, _swift_getClassOfAllocated(obj));
-  return [convertStringToNSString(&tmp) autorelease];
+  return getDescription((OpaqueValue*)&obj,
+                        _swift_getClassOfAllocated(obj));
 }
 
 static NSString *_getClassDescription(Class cls) {
@@ -388,10 +385,10 @@ static NSString *_getClassDescription(Class cls) {
 }
 
 - (NSString *)description {
-  return _getDescription(self);
+  return _getObjectDescription(self);
 }
 - (NSString *)debugDescription {
-  return _getDescription(self);
+  return _getObjectDescription(self);
 }
 
 + (NSString *)description {

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -151,7 +151,7 @@ NSString *swift::getDescription(OpaqueValue *value, const Metadata *type) {
   typedef SWIFT_CC(swift) NSString *GetDescriptionFn(OpaqueValue*, const Metadata*);
   auto getDescription = SWIFT_LAZY_CONSTANT(
     reinterpret_cast<GetDescriptionFn*>(dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation15_getDescriptionSo8NSStringCxlF)))));
+    MANGLE_AS_STRING(MANGLE_SYM(10Foundation15_getDescriptionySo8NSStringCxlF)))));
   
   // If Foundation hasn't loaded yet, fall back to returning the static string
   // "SwiftObject". The likelihood of someone invoking -description without

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -337,7 +337,6 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
 }
 
 static NSString *getValueDescription(_SwiftValue *self) {
-  String tmp;
   const Metadata *type;
   const OpaqueValue *value;
   std::tie(type, value) = getValueFromSwiftValue(self);
@@ -347,10 +346,9 @@ static NSString *getValueDescription(_SwiftValue *self) {
   auto copy = type->allocateBufferIn(&copyBuf);
   type->vw_initializeWithCopy(copy, const_cast<OpaqueValue *>(value));
 
-  swift_getSummary(&tmp, copy, type);
-
+  NSString *string = getDescription(copy, type);
   type->deallocateBufferIn(&copyBuf);
-  return convertStringToNSString(&tmp);
+  return string;
 }
 
 - (NSString *)description {

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -333,11 +333,13 @@ swift::_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound) {
 // FIXME remove
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void swift::_swift_stdlib_print_hex(__swift_uintptr_t value, int newline) {
-  if (newline != 0) {
-    printf("%016tX\n", value);
-  }
-  else {
+  if (sizeof(value) == 4) {
+    printf("%08tX", value);
+  } else {
     printf("%016tX", value);
+  }
+  if (newline) {
+    printf("\n");
   }
 }
 

--- a/test/DebugInfo/self.swift
+++ b/test/DebugInfo/self.swift
@@ -15,7 +15,7 @@ public func f() {
 //
 // CHECK: define {{.*}} @_T04self11stuffStructVACycfC(
 // CHECK-NEXT: entry:
-// CHECK-NEXT: %[[ALLOCA:.*]] = alloca %T4self11stuffStructV, align {{(4|8)}}
+// CHECK: %[[ALLOCA:.*]] = alloca %T4self11stuffStructV, align {{(4|8)}}
 // CHECK: call void @llvm.dbg.declare(metadata %T4self11stuffStructV* %[[ALLOCA]],
 // CHECK-SAME: metadata ![[SELF:.*]], metadata !DIExpression()), !dbg
 // CHECK: ![[STUFFSTRUCT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "stuffStruct",{{.*}}identifier

--- a/test/IRGen/lazy_multi_file.swift
+++ b/test/IRGen/lazy_multi_file.swift
@@ -9,7 +9,7 @@
 class Subclass : LazyContainerClass {
   final var str = "abc"
 
-  // CHECK-LABEL: @_T015lazy_multi_file8SubclassC6getStrSSyF(%T15lazy_multi_file8SubclassC* swiftself) {{.*}} {
+  // CHECK-LABEL: @_T015lazy_multi_file8SubclassC6getStrSSyF({{.*}}%T15lazy_multi_file8SubclassC* swiftself) {{.*}} {
   func getStr() -> String {
     // CHECK: = getelementptr inbounds %T15lazy_multi_file8SubclassC, %T15lazy_multi_file8SubclassC* %0, i32 0, i32 3
     return str

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -34,9 +34,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_String.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=32 alignment=4 stride=32
+// CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=24
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=16 alignment=4 stride=16 num_extra_inhabitants=1
+// CHECK-32-NEXT:     (struct size=16 alignment=4 stride=16 num_extra_inhabitants=4095
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -203,7 +203,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_multiple_types.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=121 alignment=8 stride=128 num_extra_inhabitants=0
+// CHECK-32-NEXT: (class_instance size=129 alignment=8 stride=136 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=t00 offset=8
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // (unstable implementation details omitted)
@@ -262,7 +262,7 @@ reflect(object: obj)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t16 offset=88
-// CHECK-32-NEXT:     (struct size=16 alignment=4 stride=16 num_extra_inhabitants=1
+// CHECK-32-NEXT:     (struct size=16 alignment=4 stride=16 num_extra_inhabitants=4095
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t17 offset=104
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
@@ -276,11 +276,11 @@ reflect(object: obj)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32-NEXT:   (field name=t20 offset=116
+// CHECK-32-NEXT:   (field name=t20 offset=120
 // CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-32-NEXT:   (field name=t21 offset=124
+// CHECK-32-NEXT:   (field name=t21 offset=128
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))


### PR DESCRIPTION
This PR implements support for 32-bit platforms for the new String representation.

On 32-bit platforms, this PR turns `_StringObject` into a two-word structure with `AnyObject?` and and extra `UInt` field. The latter is only used to store the 4 flags: value/subvariant/opaque/twoByte. (The value bit could be implicit in the AnyObject optional, but having a separate bit allowed me to remove some `#if` conditions.) For contiguous strings, the start address and count is stored in dedicated words of the `_StringGuts` struct (`_otherBits` and `_extraBits`, respectively).

The following test failures remain:

```
i386-apple-watchos2.0
    Swift(watchsimulator-i386) :: DebugInfo/letstring.swift
    Swift(watchsimulator-i386) :: DebugInfo/local-vars.swift.gyb
    Swift(watchsimulator-i386) :: DebugInfo/closure-multivalue.swift
    Swift(watchsimulator-i386) :: DebugInfo/closure-args2.swift
    Swift(watchsimulator-i386) :: stdlib/test_runtime_function_counters.swift
    Swift(watchsimulator-i386) :: stdlib/test_runtime_function_counters_with_disabled_assertions.swift
```

I think this is nevertheless ready to merge. (It's still an overall improvement, since we can now at least run on 32-bit platforms.)
