### PR TITLE
Add bound checks for range subscripts in String and friends

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -89,6 +89,34 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public var endIndex: Index { return Index(encodedOffset: _guts.count) }
 
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _boundsCheck(_ index: Index) {
+    _precondition(index.encodedOffset >= 0 && index.encodedOffset < _guts.count,
+      "String index is out of bounds")
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _boundsCheck(_ range: Range<Index>) {
+    _precondition(
+      range.lowerBound.encodedOffset >= 0 &&
+      range.upperBound.encodedOffset <= _guts.count,
+      "String index range is out of bounds")
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _boundsCheck(_ range: ClosedRange<Index>) {
+    _precondition(
+      range.lowerBound.encodedOffset >= 0 &&
+      range.upperBound.encodedOffset < _guts.count,
+      "String index range is out of bounds")
+  }
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal func _index(atEncodedOffset offset: Int) -> Index {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -433,6 +433,9 @@ extension Substring.${View} : BidirectionalCollection {
   }
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(r: Range<Index>) -> SubSequence {
+    // FIXME(strings): tests.
+    _precondition(r.lowerBound >= startIndex && r.upperBound <= endIndex,
+      "${View} index range out of bounds")
     return Substring.${View}(_wholeString.${property}, _bounds: r)
   }
 }
@@ -607,6 +610,7 @@ extension String {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, introduced: 4)
   public subscript(r: Range<Index>) -> Substring {
+    _boundsCheck(r)
     return Substring(
       _slice: Slice(base: self, bounds: r))
   }
@@ -614,12 +618,14 @@ extension String {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4)
   public subscript(bounds: Range<Index>) -> String {
+    _boundsCheck(bounds)
     return String(Substring(_slice: Slice(base: self, bounds: bounds)))
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4)
   public subscript(bounds: ClosedRange<Index>) -> String {
+    _boundsCheck(bounds)
     return String(Substring(_slice: Slice(
           base: self,
           bounds: bounds.relative(to: self))))

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -301,6 +301,28 @@ StringTests.test("ForeignIndexes/subscript(Range)/OutOfBoundsTrap/2") {
   _ = acceptor[r]
 }
 
+StringTests.test("ForeignIndexes/subscript(ClosedRange)/OutOfBoundsTrap/1") {
+  let donor = "abcdef"
+  let acceptor = "uvw"
+
+  expectEqual("uvw", acceptor[donor.startIndex...donor.index(_nth: 2)])
+
+  let r = donor.startIndex...donor.index(_nth: 3)
+  expectCrashLater()
+  _ = acceptor[r]
+}
+
+StringTests.test("ForeignIndexes/subscript(ClosedRange)/OutOfBoundsTrap/2") {
+  let donor = "abcdef"
+  let acceptor = "uvw"
+
+  expectEqual("uvw", acceptor[donor.startIndex...donor.index(_nth: 2)])
+
+  let r = donor.index(_nth: 3)...donor.index(_nth: 5)
+  expectCrashLater()
+  _ = acceptor[r]
+}
+
 StringTests.test("ForeignIndexes/replaceSubrange/OutOfBoundsTrap/1") {
   let donor = "abcdef"
   var acceptor = "uvw"


### PR DESCRIPTION
More audit is needed, but I think this plugs the most obvious memory safety holes.
