### PR TITLE
[utf8] Give StringProtocol.SubSequence default of Substring to suppress warning

### DIFF
--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -34,6 +34,8 @@ public protocol StringProtocol
   associatedtype UnicodeScalarView : BidirectionalCollection
   where UnicodeScalarView.Element == Unicode.Scalar,
         UnicodeScalarView.Index == Index
+        
+  associatedtype SubSequence = Substring
 
   var utf8: UTF8View { get }
   var utf16: UTF16View { get }


### PR DESCRIPTION
Same as apple/swift#19412