### PR TITLE
[utf8] Cherry-pick ownership annotations

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -154,7 +154,7 @@ extension EnumeratedSequence.Iterator: IteratorProtocol, Sequence {
 extension EnumeratedSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   @inlinable
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
 }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1084,7 +1084,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   @_semantics("array.mutate_unknown")
   internal mutating func _appendElementAssumeUniqueAndCapacity(
     _ oldCount: Int,
-    newElement: Element
+    newElement: __owned Element
   ) {
     _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
     _sanityCheck(_buffer.capacity >= _buffer.count + 1)
@@ -1116,7 +1116,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   ///   same array.
   @inlinable
   @_semantics("array.append_element")
-  public mutating func append(_ newElement: Element) {
+  public mutating func append(_ newElement: __owned Element) {
     _makeUniqueAndReserveCapacityIfNotUnique()
     let oldCount = _getCount()
     _reserveCapacityAssumingUniqueBuffer(oldCount: oldCount)
@@ -1141,7 +1141,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   ///   array.
   @inlinable
   @_semantics("array.append_contentsOf")
-  public mutating func append<S: Sequence>(contentsOf newElements: S)
+  public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
 
     let newElementsCount = newElements.underestimatedCount
@@ -1246,7 +1246,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   /// - Complexity: O(*n*), where *n* is the length of the array. If
   ///   `i == endIndex`, this method is equivalent to `append(_:)`.
   @inlinable
-  public mutating func insert(_ newElement: Element, at i: Int) {
+  public mutating func insert(_ newElement: __owned Element, at i: Int) {
     _checkIndex(i)
     self.replaceSubrange(i..<i, with: CollectionOfOne(newElement))
   }
@@ -1561,7 +1561,7 @@ extension Array {
   @_semantics("array.mutate_unknown")
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
-    with newElements: C
+    with newElements: __owned C
   ) where C: Collection, C.Element == Element {
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
       "Array replace: subrange start is negative")

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -43,7 +43,7 @@ internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   /// - Precondition: The elements actually have dynamic type `U`, and `U`
   ///   is a class or `@objc` existential.
   @inlinable
-  internal func cast<U>(toBufferOf _: U.Type) -> _ArrayBuffer<U> {
+  __consuming internal func cast<U>(toBufferOf _: U.Type) -> _ArrayBuffer<U> {
     _sanityCheck(_isClassOrObjCExistential(Element.self))
     _sanityCheck(_isClassOrObjCExistential(U.self))
     return _ArrayBuffer<U>(storage: _storage)
@@ -60,7 +60,7 @@ internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   /// - Precondition: `U` is a class or `@objc` existential derived from
   /// `Element`.
   @inlinable
-  internal func downcast<U>(
+  __consuming internal func downcast<U>(
     toBufferWithDeferredTypeCheckOf _: U.Type
   ) -> _ArrayBuffer<U> {
     _sanityCheck(_isClassOrObjCExistential(Element.self))
@@ -214,7 +214,7 @@ extension _ArrayBuffer {
   /// just-initialized memory.
   @inlinable
   @discardableResult
-  internal func _copyContents(
+  __consuming internal func _copyContents(
     subRange bounds: Range<Int>,
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element> {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -30,7 +30,7 @@ internal protocol _ArrayBufferProtocol
   /// memory starting at `target`.  Return a pointer "past the end" of the
   /// just-initialized memory.
   @discardableResult
-  func _copyContents(
+  __consuming func _copyContents(
     subRange bounds: Range<Int>,
     initializing target: UnsafeMutablePointer<Element>
   ) -> UnsafeMutablePointer<Element>
@@ -74,7 +74,7 @@ internal protocol _ArrayBufferProtocol
   mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
     with newCount: Int,
-    elementsOf newValues: C
+    elementsOf newValues: __owned C
   ) where C : Collection, C.Element == Element
 
   /// Returns a `_SliceBuffer` containing the elements in `bounds`.
@@ -149,7 +149,7 @@ extension _ArrayBufferProtocol where Indices == Range<Int>{
   internal mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
     with newCount: Int,
-    elementsOf newValues: C
+    elementsOf newValues: __owned C
   ) where C : Collection, C.Element == Element {
     _sanityCheck(startIndex == 0, "_SliceBuffer should override this function.")
     let oldCount = self.count

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -88,7 +88,7 @@ extension _ArrayBufferProtocol {
   @inline(never)
   internal mutating func _arrayOutOfPlaceReplace<C: Collection>(
     _ bounds: Range<Int>,
-    with newValues: C,
+    with newValues: __owned C,
     count insertCount: Int
   ) where C.Element == Element {
 
@@ -285,7 +285,7 @@ extension _ArrayBufferProtocol {
   /// Append items from `newItems` to a buffer.
   @inlinable
   internal mutating func _arrayAppendSequence<S: Sequence>(
-    _ newItems: S
+    _ newItems: __owned S
   ) where S.Element == Element {
     
     // this function is only ever called from append(contentsOf:)

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -903,7 +903,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
   @_semantics("array.mutate_unknown")
   internal mutating func _appendElementAssumeUniqueAndCapacity(
     _ oldCount: Int,
-    newElement: Element
+    newElement: __owned Element
   ) {
     _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
     _sanityCheck(_buffer.capacity >= _buffer.count + 1)
@@ -935,7 +935,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
   ///   same array.
   @inlinable
   @_semantics("array.append_element")
-  public mutating func append(_ newElement: Element) {
+  public mutating func append(_ newElement: __owned Element) {
     _makeUniqueAndReserveCapacityIfNotUnique()
     let oldCount = _getCount()
     _reserveCapacityAssumingUniqueBuffer(oldCount: oldCount)
@@ -960,7 +960,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
   ///   array.
   @inlinable
   @_semantics("array.append_contentsOf")
-  public mutating func append<S: Sequence>(contentsOf newElements: S)
+  public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
 
     let newElementsCount = newElements.underestimatedCount
@@ -1065,7 +1065,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
   /// - Complexity: O(*n*), where *n* is the length of the array. If
   ///   `i == endIndex`, this method is equivalent to `append(_:)`.
   @inlinable
-  public mutating func insert(_ newElement: Element, at i: Int) {
+  public mutating func insert(_ newElement: __owned Element, at i: Int) {
     _checkIndex(i)
     self.replaceSubrange(i..<i, with: CollectionOfOne(newElement))
   }
@@ -1100,7 +1100,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
   }
 
   @inlinable
-  public func _copyToContiguousArray() -> ContiguousArray<Element> {
+  public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
       return ContiguousArray(_buffer: n)
     }
@@ -1260,7 +1260,7 @@ extension ArraySlice {
   }
 
   @inlinable
-  public func _copyContents(
+  public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
 
@@ -1330,7 +1330,7 @@ extension ArraySlice {
   @_semantics("array.mutate_unknown")
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
-    with newElements: C
+    with newElements: __owned C
   ) where C: Collection, C.Element == Element {
     _precondition(subrange.lowerBound >= _buffer.startIndex,
       "ArraySlice replace: subrange start is before the startIndex")

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -51,7 +51,7 @@ internal protocol ArrayProtocol
   /// - Complexity: O(`self.count`).
   ///
   /// - Precondition: `startIndex <= i`, `i <= endIndex`.
-  mutating func insert(_ newElement: Element, at i: Int)
+  mutating func insert(_ newElement: __owned Element, at i: Int)
 
   /// Remove and return the element at the given index.
   ///
@@ -77,7 +77,7 @@ extension ArrayProtocol {
   // efficient, we should make the default implementation coming from Sequence
   // preferred.
   @inlinable
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _filter(isIncluded)

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -382,7 +382,7 @@ extension BidirectionalCollection {
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
   ///   elements to drop.
   @inlinable // protocol-only
-  public func dropLast(_ k: Int) -> SubSequence {
+  public __consuming func dropLast(_ k: Int) -> SubSequence {
     _precondition(
       k >= 0, "Can't drop a negative number of elements from a collection")
     let end = index(
@@ -413,7 +413,7 @@ extension BidirectionalCollection {
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is equal to
   ///   `maxLength`.
   @inlinable // protocol-only
-  public func suffix(_ maxLength: Int) -> SubSequence {
+  public __consuming func suffix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1120,7 +1120,7 @@ extension Collection where Iterator == IndexingIterator<Self> {
   /// Returns an iterator over the elements of the collection.
   @inlinable // trivial-implementation
   @inline(__always)
-  public func makeIterator() -> IndexingIterator<Self> {
+  public __consuming func makeIterator() -> IndexingIterator<Self> {
     return IndexingIterator(_elements: self)
   }
 }
@@ -1356,7 +1356,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
   ///   elements to drop from the beginning of the collection.
   @inlinable
-  public func dropFirst(_ k: Int) -> SubSequence {
+  public __consuming func dropFirst(_ k: Int) -> SubSequence {
     _precondition(k >= 0, "Can't drop a negative number of elements from a collection")
     let start = index(startIndex,
       offsetBy: k, limitedBy: endIndex) ?? endIndex
@@ -1384,7 +1384,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length of
   ///   the collection.
   @inlinable
-  public func dropLast(_ k: Int) -> SubSequence {
+  public __consuming func dropLast(_ k: Int) -> SubSequence {
     _precondition(
       k >= 0, "Can't drop a negative number of elements from a collection")
     let amount = Swift.max(0, count - k)
@@ -1403,7 +1403,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func drop(
+  public __consuming func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var start = startIndex
@@ -1434,7 +1434,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
   ///   elements to select from the beginning of the collection.
   @inlinable
-  public func prefix(_ maxLength: Int) -> SubSequence {
+  public __consuming func prefix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,
       "Can't take a prefix of negative length from a collection")
@@ -1453,7 +1453,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func prefix(
+  public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var end = startIndex
@@ -1484,7 +1484,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length of
   ///   the collection.
   @inlinable
-  public func suffix(_ maxLength: Int) -> SubSequence {
+  public __consuming func suffix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
@@ -1529,7 +1529,7 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func prefix(upTo end: Index) -> SubSequence {
+  public __consuming func prefix(upTo end: Index) -> SubSequence {
     return self[startIndex..<end]
   }
 
@@ -1567,7 +1567,7 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func suffix(from start: Index) -> SubSequence {
+  public __consuming func suffix(from start: Index) -> SubSequence {
     return self[start..<endIndex]
   }
 
@@ -1601,7 +1601,7 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func prefix(through position: Index) -> SubSequence {
+  public __consuming func prefix(through position: Index) -> SubSequence {
     return prefix(upTo: index(after: position))
   }
 
@@ -1654,7 +1654,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func split(
+  public __consuming func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
     whereSeparator isSeparator: (Element) throws -> Bool
@@ -1749,7 +1749,7 @@ extension Collection where Element : Equatable {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func split(
+  public __consuming func split(
     separator: Element,
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -117,7 +117,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   ///
   /// - Complexity: O(1)
   @inlinable // trivial-implementation
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_elements: _element)
   }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -729,7 +729,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
   @_semantics("array.mutate_unknown")
   internal mutating func _appendElementAssumeUniqueAndCapacity(
     _ oldCount: Int,
-    newElement: Element
+    newElement: __owned Element
   ) {
     _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
     _sanityCheck(_buffer.capacity >= _buffer.count + 1)
@@ -891,7 +891,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
   /// - Complexity: O(*n*), where *n* is the length of the array. If
   ///   `i == endIndex`, this method is equivalent to `append(_:)`.
   @inlinable
-  public mutating func insert(_ newElement: Element, at i: Int) {
+  public mutating func insert(_ newElement: __owned Element, at i: Int) {
     _checkIndex(i)
     self.replaceSubrange(i..<i, with: CollectionOfOne(newElement))
   }
@@ -926,7 +926,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
   }
 
   @inlinable
-  public func _copyToContiguousArray() -> ContiguousArray<Element> {
+  public __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
     if let n = _buffer.requestNativeBuffer() {
       return ContiguousArray(_buffer: n)
     }
@@ -1086,7 +1086,7 @@ extension ContiguousArray {
   }
 
   @inlinable
-  public func _copyContents(
+  public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
 
@@ -1157,7 +1157,7 @@ extension ContiguousArray {
   @_semantics("array.mutate_unknown")
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Int>,
-    with newElements: C
+    with newElements: __owned C
   ) where C: Collection, C.Element == Element {
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
       "ContiguousArray replace: subrange start is negative")

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -588,7 +588,7 @@ extension Dictionary {
   /// - Returns: A dictionary of the key-value pairs that `isIncluded` allows.
   @inlinable
   @available(swift, introduced: 4.0)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Key: Value] {
     var result = Dictionary()

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -83,8 +83,8 @@ extension LazyDropWhileSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // lazy-performance
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
 }
@@ -101,8 +101,8 @@ extension LazySequenceProtocol {
   ///   its argument and returns `true` if the element should be skipped or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
-  public func drop(
+  @inlinable // lazy-performance
+  public __consuming func drop(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhileSequence<Self.Elements> {
     return LazyDropWhileSequence(_base: self.elements, predicate: predicate)
@@ -141,8 +141,8 @@ extension LazyDropWhileCollection: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // lazy-performance
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
 }
@@ -247,8 +247,8 @@ extension LazyCollectionProtocol {
   ///   as its argument and returns `true` if the element should be skipped or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
-  public func drop(
+  @inlinable // lazy-performance
+  public __consuming func drop(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhileCollection<Self.Elements> {
     return LazyDropWhileCollection(

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -334,9 +334,9 @@ internal class _AnyRandomAccessCollectionBox<Element>
   /*
   var _indices: Indices
 
-  func prefix(upTo end: Index) -> SubSequence
+  __consuming func prefix(upTo end: Index) -> SubSequence
 
-  func suffix(from start: Index) -> SubSequence
+  __consuming func suffix(from start: Index) -> SubSequence
 
   func prefix(through position: Index) -> SubSequence
 
@@ -714,7 +714,7 @@ extension Any${Kind} {
 %   end
   @inline(__always)
   @inlinable
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return _box._makeIterator()
   }
 
@@ -731,55 +731,55 @@ extension Any${Kind} {
   }
 
   @inlinable
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _box._filter(isIncluded)
   }
 
   @inlinable
-  public func forEach(
+  public __consuming func forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     return try _box._forEach(body)
   }
 
   @inlinable
-  public func drop(
+  public __consuming func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._drop(while: predicate))
   }
 
   @inlinable
-  public func dropFirst(_ n: Int) -> Any${Kind}<Element> {
+  public __consuming func dropFirst(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropFirst(n))
   }
 
   @inlinable
-  public func dropLast(_ n: Int) -> Any${Kind}<Element> {
+  public __consuming func dropLast(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropLast(n))
   }
 
   @inlinable
-  public func prefix(
+  public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._prefix(while: predicate))
   }
 
   @inlinable
-  public func prefix(_ maxLength: Int) -> Any${Kind}<Element> {
+  public __consuming func prefix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._prefix(maxLength))
   }
 
   @inlinable
-  public func suffix(_ maxLength: Int) -> Any${Kind}<Element> {
+  public __consuming func suffix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._suffix(maxLength))
   }
 
   @inlinable
-  public func split(
+  public __consuming func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
     whereSeparator isSeparator: (Element) throws -> Bool

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -89,7 +89,7 @@ extension LazyFilterSequence: LazySequenceProtocol {
   ///
   /// - Complexity: O(1).
   @inlinable // lazy-performance
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _predicate)
   }
 
@@ -153,7 +153,7 @@ extension LazyFilterCollection : LazySequenceProtocol {
   ///
   /// - Complexity: O(1).
   @inlinable // lazy-performance
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _predicate)
   }
 
@@ -365,7 +365,7 @@ extension LazySequenceProtocol {
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   @inlinable // lazy-performance
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: @escaping (Elements.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
     return LazyFilterSequence(_base: self.elements, isIncluded)
@@ -380,7 +380,7 @@ extension LazyCollectionProtocol {
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   @inlinable // lazy-performance
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: @escaping (Elements.Element) -> Bool
   ) -> LazyFilterCollection<Self.Elements> {
     return LazyFilterCollection(_base: self.elements, isIncluded)
@@ -389,7 +389,7 @@ extension LazyCollectionProtocol {
 
 extension LazyFilterSequence {
   @available(swift, introduced: 5)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: @escaping (Element) -> Bool
   ) -> LazyFilterSequence<Base> {
     return LazyFilterSequence(_base: _base) {
@@ -400,7 +400,7 @@ extension LazyFilterSequence {
 
 extension LazyFilterCollection {
   @available(swift, introduced: 5)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: @escaping (Element) -> Bool
   ) -> LazyFilterCollection<Base> {
     return LazyFilterCollection(_base: _base) {

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -92,7 +92,7 @@ extension FlattenSequence: Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable // lazy-performance
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
 }
@@ -122,7 +122,7 @@ extension Sequence where Element : Sequence {
   /// - Returns: A flattened view of the elements of this
   ///   sequence of sequences.
   @inlinable // lazy-performance
-  public func joined() -> FlattenSequence<Self> {
+  public __consuming func joined() -> FlattenSequence<Self> {
     return FlattenSequence(_base: self)
   }
 }
@@ -131,7 +131,7 @@ extension LazySequenceProtocol where Element : Sequence {
   /// Returns a lazy sequence that concatenates the elements of this sequence of
   /// sequences.
   @inlinable // lazy-performance
-  public func joined() -> LazySequence<FlattenSequence<Elements>> {
+  public __consuming func joined() -> LazySequence<FlattenSequence<Elements>> {
     return FlattenSequence(_base: elements).lazy
   }
 }
@@ -251,7 +251,7 @@ extension FlattenCollection : Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable // lazy-performance
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
 
@@ -514,7 +514,7 @@ extension Collection where Element : Collection {
   /// - Returns: A flattened view of the elements of this
   ///   collection of collections.
   @inlinable // lazy-performance
-  public func joined() -> FlattenCollection<Self> {
+  public __consuming func joined() -> FlattenCollection<Self> {
     return FlattenCollection(self)
   }
 }
@@ -523,7 +523,7 @@ extension LazyCollectionProtocol
   where Self : Collection, Element : Collection {
   /// A concatenation of the elements of `self`.
   @inlinable // lazy-performance
-  public func joined() -> LazyCollection<FlattenCollection<Elements>> {
+  public __consuming func joined() -> LazyCollection<FlattenCollection<Elements>> {
     return FlattenCollection(elements).lazy
   }
 }

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -126,7 +126,7 @@ extension JoinedSequence: Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable // lazy-performance
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(base: _base.makeIterator(), separator: _separator)
   }
 
@@ -184,7 +184,7 @@ extension Sequence where Element : Sequence {
   ///   sequence's elements.
   /// - Returns: The joined sequence of elements.
   @inlinable // lazy-performance
-  public func joined<Separator : Sequence>(
+  public __consuming func joined<Separator : Sequence>(
     separator: Separator
   ) -> JoinedSequence<Self>
     where Separator.Element == Element.Element {

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -79,7 +79,7 @@ extension LazyCollection : Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return _base.makeIterator()
   }
 

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -74,7 +74,7 @@ extension LazyMapSequence: LazySequenceProtocol {
   ///
   /// - Complexity: O(1).
   @inlinable
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _transform: _transform)
   }
 
@@ -119,7 +119,7 @@ extension LazyMapCollection: Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _transform: _transform)
   }
 

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -1163,7 +1163,7 @@ extension Dictionary {
   }
 
   @available(swift, obsoleted: 4.0)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool, obsoletedInSwift4: () = ()
   ) rethrows -> [Element] {
     var result: [Element] = []
@@ -1178,7 +1178,7 @@ extension Dictionary {
 
 extension Set {
   @available(swift, obsoleted: 4.0)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool, obsoletedInSwift4: () = ()
   ) rethrows -> [Element] {
     var result: [Element] = []

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -74,8 +74,8 @@ extension LazyPrefixWhileSequence.Iterator: IteratorProtocol, Sequence {
 extension LazyPrefixWhileSequence: Sequence {
   public typealias SubSequence = AnySequence<Element> // >:(
   
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // lazy-performance
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
 }
@@ -92,8 +92,8 @@ extension LazySequenceProtocol {
   ///   its argument and returns `true` if the element should be included or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
-  public func prefix(
+  @inlinable // lazy-performance
+  public __consuming func prefix(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyPrefixWhileSequence<Self.Elements> {
     return LazyPrefixWhileSequence(_base: self.elements, predicate: predicate)
@@ -129,8 +129,8 @@ public struct LazyPrefixWhileCollection<Base: Collection> {
 extension LazyPrefixWhileCollection: Sequence {
   public typealias Iterator = LazyPrefixWhileSequence<Base>.Iterator
   
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // lazy-performance
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
 }
@@ -303,8 +303,8 @@ extension LazyCollectionProtocol {
   ///   as its argument and returns `true` if the element should be included
   ///   or `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
-  public func prefix(
+  @inlinable // lazy-performance
+  public __consuming func prefix(
     while predicate: @escaping (Element) -> Bool
   ) -> LazyPrefixWhileCollection<Elements> {
     return LazyPrefixWhileCollection(

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -619,7 +619,7 @@ extension PartialRangeFrom: Sequence
 
   /// Returns an iterator for this sequence.
   @inlinable
-  public func makeIterator() -> Iterator { 
+  public __consuming func makeIterator() -> Iterator { 
     return Iterator(_current: lowerBound) 
   }
 }

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -109,7 +109,7 @@ public protocol RangeReplaceableCollection : Collection
   ///   equivalent to `append(contentsOf:)`.
   mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
-    with newElements: C
+    with newElements: __owned C
   ) where C : Collection, C.Element == Element
 
   /// Prepares the collection to store the specified number of elements, when
@@ -423,7 +423,7 @@ extension RangeReplaceableCollection {
   /// - Complexity: O(1) on average, over many calls to `append(_:)` on the
   ///   same collection.
   @inlinable
-  public mutating func append(_ newElement: Element) {
+  public mutating func append(_ newElement: __owned Element) {
     insert(newElement, at: endIndex)
   }
 
@@ -445,7 +445,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Complexity: O(*m*), where *m* is the length of `newElements`.
   @inlinable
-  public mutating func append<S : Sequence>(contentsOf newElements: S)
+  public mutating func append<S : Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
 
     let approximateCapacity = self.count +
@@ -481,7 +481,7 @@ extension RangeReplaceableCollection {
   ///   `i == endIndex`, this method is equivalent to `append(_:)`.
   @inlinable
   public mutating func insert(
-    _ newElement: Element, at i: Index
+    _ newElement: __owned Element, at i: Index
   ) {
     replaceSubrange(i..<i, with: CollectionOfOne(newElement))
   }
@@ -513,7 +513,7 @@ extension RangeReplaceableCollection {
   ///   is equivalent to `append(contentsOf:)`.
   @inlinable
   public mutating func insert<C : Collection>(
-    contentsOf newElements: C, at i: Index
+    contentsOf newElements: __owned C, at i: Index
   ) where C.Element == Element {
     replaceSubrange(i..<i, with: newElements)
   }
@@ -744,7 +744,7 @@ extension RangeReplaceableCollection {
   @inlinable
   public mutating func replaceSubrange<C: Collection, R: RangeExpression>(
     _ subrange: R,
-    with newElements: C
+    with newElements: __owned C
   ) where C.Element == Element, R.Bound == Index {
     self.replaceSubrange(subrange.relative(to: self), with: newElements)
   }
@@ -1079,7 +1079,7 @@ extension RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
   @available(swift, introduced: 4.0)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Self {
     return try Self(self.lazy.filter(isIncluded))

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -104,7 +104,7 @@ extension ReversedCollection: Sequence {
 
   @inlinable
   @inline(__always)
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base)
   }
 }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -637,7 +637,7 @@ extension Sequence where Self: IteratorProtocol {
 extension Sequence where Self.Iterator == Self {
   /// Returns an iterator over the elements of this sequence.
   @inlinable
-  public func makeIterator() -> Self {
+  public __consuming func makeIterator() -> Self {
     return self
   }
 }
@@ -666,7 +666,7 @@ internal struct _DropFirstSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func makeIterator() -> _DropFirstSequence<Base> {
+  __consuming internal func makeIterator() -> _DropFirstSequence<Base> {
     return self
   }
 
@@ -683,7 +683,7 @@ internal struct _DropFirstSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func dropFirst(_ k: Int) -> AnySequence<Base.Element> {
+  internal __consuming func dropFirst(_ k: Int) -> AnySequence<Base.Element> {
     // If this is already a _DropFirstSequence, we need to fold in
     // the current drop count and drop limit so no data is lost.
     //
@@ -718,7 +718,7 @@ internal struct _PrefixSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func makeIterator() -> _PrefixSequence<Base> {
+  __consuming internal func makeIterator() -> _PrefixSequence<Base> {
     return self
   }
 
@@ -736,7 +736,7 @@ internal struct _PrefixSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func prefix(_ maxLength: Int) -> AnySequence<Base.Element> {
+  internal __consuming func prefix(_ maxLength: Int) -> AnySequence<Base.Element> {
     return AnySequence(
       _PrefixSequence(
         _iterator: _iterator,
@@ -777,7 +777,7 @@ internal struct _DropWhileSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func makeIterator() -> _DropWhileSequence<Base> {
+  __consuming internal func makeIterator() -> _DropWhileSequence<Base> {
     return self
   }
 
@@ -793,7 +793,7 @@ internal struct _DropWhileSequence<Base : IteratorProtocol>
   }
 
   @inlinable
-  internal func drop(
+  internal __consuming func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> AnySequence<Element> {
     // If this is already a _DropWhileSequence, avoid multiple
@@ -867,7 +867,7 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _filter(isIncluded)
@@ -1039,7 +1039,7 @@ extension Sequence where Element : Equatable {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func split(
+  public __consuming func split(
     separator: Element,
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true
@@ -1103,7 +1103,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func split(
+  public __consuming func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
     whereSeparator isSeparator: (Element) throws -> Bool
@@ -1168,7 +1168,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func suffix(_ maxLength: Int) -> AnySequence<Element> {
+  public __consuming func suffix(_ maxLength: Int) -> AnySequence<Element> {
     _precondition(maxLength >= 0, "Can't take a suffix of negative length from a sequence")
     if maxLength == 0 { return AnySequence([]) }
     // FIXME: <rdar://problem/21885650> Create reusable RingBuffer<T>
@@ -1220,7 +1220,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///   where *k* is the number of elements to drop from the beginning of
   ///   the sequence.
   @inlinable
-  public func dropFirst(_ k: Int) -> AnySequence<Element> {
+  public __consuming func dropFirst(_ k: Int) -> AnySequence<Element> {
     _precondition(k >= 0, "Can't drop a negative number of elements from a sequence")
     if k == 0 { return AnySequence(self) }
     return AnySequence(_DropFirstSequence(_iterator: makeIterator(), limit: k))
@@ -1245,7 +1245,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func dropLast(_ k: Int) -> AnySequence<Element> {
+  public __consuming func dropLast(_ k: Int) -> AnySequence<Element> {
     _precondition(k >= 0, "Can't drop a negative number of elements from a sequence")
     if k == 0 { return AnySequence(self) }
 
@@ -1295,7 +1295,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   /// - Complexity: O(*k*), where *k* is the number of elements to drop from
   ///   the beginning of the sequence.
   @inlinable
-  public func drop(
+  public __consuming func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> AnySequence<Element> {
     return try AnySequence(
@@ -1322,7 +1322,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func prefix(_ maxLength: Int) -> AnySequence<Element> {
+  public __consuming func prefix(_ maxLength: Int) -> AnySequence<Element> {
     _precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
     if maxLength == 0 {
       return AnySequence(EmptyCollection<Element>())
@@ -1354,7 +1354,7 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(*k*), where *k* is the length of the result.
   @inlinable
-  public func prefix(
+  public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> AnySequence<Element> {
     var result: [Element] = []
@@ -1390,7 +1390,7 @@ extension Sequence {
   ///
   /// - Complexity: O(1)
   @inlinable
-  public func dropFirst() -> SubSequence { return dropFirst(1) }
+  public __consuming func dropFirst() -> SubSequence { return dropFirst(1) }
 
   /// Returns a subsequence containing all but the last element of the
   /// sequence.
@@ -1411,7 +1411,7 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func dropLast() -> SubSequence  { return dropLast(1) }
+  public __consuming func dropLast() -> SubSequence  { return dropLast(1) }
 }
 
 extension Sequence {
@@ -1423,7 +1423,7 @@ extension Sequence {
   /// - Postcondition: The `Pointee`s at `buffer[startIndex..<returned index]` are
   ///   initialized.
   @inlinable
-  public func _copyContents(
+  public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
       var it = self.makeIterator()

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -41,8 +41,8 @@ extension _SequenceWrapper  {
 }
 
 extension _SequenceWrapper where Iterator == Base.Iterator {
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // generic-performance
+  public __consuming func makeIterator() -> Iterator {
     return self._base.makeIterator()
   }
   
@@ -63,8 +63,8 @@ extension _SequenceWrapper {
     return try _base.map(transform)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  public func filter(
+  @inlinable // generic-performance
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _base.filter(isIncluded)
@@ -82,47 +82,47 @@ extension _SequenceWrapper {
     return _base._customContainsEquatableElement(element)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  public func _copyToContiguousArray()
+  @inlinable // generic-performance
+  public __consuming func _copyToContiguousArray()
     -> ContiguousArray<Element> {
     return _base._copyToContiguousArray()
   }
 }
 
 extension _SequenceWrapper where SubSequence == Base.SubSequence {
-  @inlinable // FIXME(sil-serialize-all)
-  public func dropFirst(_ n: Int) -> SubSequence {
+  @inlinable // generic-performance
+  public __consuming func dropFirst(_ n: Int) -> SubSequence {
     return _base.dropFirst(n)
   }
-  @inlinable // FIXME(sil-serialize-all)
-  public func dropLast(_ n: Int) -> SubSequence {
+  @inlinable // generic-performance
+  public __consuming func dropLast(_ n: Int) -> SubSequence {
     return _base.dropLast(n)
   }
-  @inlinable // FIXME(sil-serialize-all)
-  public func prefix(_ maxLength: Int) -> SubSequence {
+  @inlinable // generic-performance
+  public __consuming func prefix(_ maxLength: Int) -> SubSequence {
     return _base.prefix(maxLength)
   }
-  @inlinable // FIXME(sil-serialize-all)
-  public func suffix(_ maxLength: Int) -> SubSequence {
+  @inlinable // generic-performance
+  public __consuming func suffix(_ maxLength: Int) -> SubSequence {
     return _base.suffix(maxLength)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  public func drop(
+  @inlinable // generic-performance
+  public __consuming func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     return try _base.drop(while: predicate)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  public func prefix(
+  @inlinable // generic-performance
+  public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     return try _base.prefix(while: predicate)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  public func split(
+  @inlinable // generic-performance
+  public __consuming func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool
   ) rethrows -> [SubSequence] {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -233,7 +233,7 @@ extension Set: Sequence {
   /// Returns an iterator over the members of the set.
   @inlinable
   @inline(__always)
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return _variant.makeIterator()
   }
 
@@ -290,7 +290,7 @@ extension Set {
   /// - Returns: A set of the elements that `isIncluded` allows.
   @inlinable
   @available(swift, introduced: 4.0)
-  public func filter(
+  public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Set {
     var result = Set()
@@ -3074,7 +3074,7 @@ extension Set._Variant: _SetBuffer {
   /// - Complexity: O(1).
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
-  internal func makeIterator() -> Set<Element>.Iterator {
+  __consuming internal func makeIterator() -> Set<Element>.Iterator {
     switch self {
     case .native(let nativeSet):
       return ._native(nativeSet.makeIterator())
@@ -3373,7 +3373,7 @@ extension _NativeSet: Sequence {
   }
 
   @inlinable
-  internal func makeIterator() -> Iterator {
+  __consuming internal func makeIterator() -> Iterator {
     return Iterator(self)
   }
 }
@@ -3432,7 +3432,7 @@ extension _CocoaSet: Sequence {
   }
 
   @usableFromInline
-  internal func makeIterator() -> Iterator {
+  __consuming internal func makeIterator() -> Iterator {
     return Iterator(self)
   }
 }

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -273,7 +273,7 @@ extension StrideTo: Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable
-  public func makeIterator() -> StrideToIterator<Element> {
+  public __consuming func makeIterator() -> StrideToIterator<Element> {
     return StrideToIterator(_start: _start, end: _end, stride: _stride)
   }
 
@@ -488,7 +488,7 @@ extension StrideThrough: Sequence {
   ///
   /// - Complexity: O(1).
   @inlinable
-  public func makeIterator() -> StrideThroughIterator<Element> {
+  public __consuming func makeIterator() -> StrideThroughIterator<Element> {
     return StrideThroughIterator(_start: _start, end: _end, stride: _stride)
   }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -979,7 +979,7 @@ extension Sequence where Element: StringProtocol {
 // This overload is necessary because String now conforms to
 // BidirectionalCollection, and there are other `joined` overloads that are
 // considered more specific. See Flatten.swift.gyb.
-extension BidirectionalCollection where Iterator.Element == String {
+extension BidirectionalCollection where Element == String {
   /// Returns a new string by concatenating the elements of the sequence,
   /// adding the given separator between each element.
   ///

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -139,8 +139,8 @@ extension Zip2Sequence: Sequence {
   public typealias Element = (Sequence1.Element, Sequence2.Element)
 
   /// Returns an iterator over the elements of this sequence.
-  @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  @inlinable // generic-performance
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(
       _sequence1.makeIterator(),
       _sequence2.makeIterator())

--- a/stdlib/public/core/old_CharacterUnicodeScalars.swift
+++ b/stdlib/public/core/old_CharacterUnicodeScalars.swift
@@ -49,7 +49,7 @@ extension Character.UnicodeScalarView.Iterator : IteratorProtocol {
 
 extension Character.UnicodeScalarView : Sequence {
   @inlinable // FIXME(sil-serialize-all)
-  public func makeIterator() -> Iterator {
+  public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: IndexingIterator(_elements: self))
   }
 }

--- a/test/IDE/print_type_interface.swift
+++ b/test/IDE/print_type_interface.swift
@@ -71,15 +71,15 @@ extension D {
 // RUN: %target-swift-ide-test -print-type-interface -usr=_TtGSaSi_ -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE4
 // TYPE4-DAG: public typealias Index = Int
 // TYPE4-DAG: public func min() -> Int?
-// TYPE4-DAG: public mutating func insert<C>(contentsOf newElements: C, at i: Int)
+// TYPE4-DAG: public mutating func insert<C>(contentsOf newElements: __owned C, at i: Int)
 // TYPE4-DAG: public mutating func removeFirst(_ k: Int)
-// TYPE4-DAG: public func makeIterator() -> IndexingIterator<Array<Int>>
+// TYPE4-DAG: public __consuming func makeIterator() -> IndexingIterator<Array<Int>>
 // TYPE4-NOT: public func joined
 
 // RUN: %target-swift-ide-test -print-type-interface -usr=_TtGSaSS_ -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE5
-// TYPE5-DAG: public func prefix(_ maxLength: Int) -> ArraySlice<String>
-// TYPE5-DAG: public func suffix(_ maxLength: Int) -> ArraySlice<String>
-// TYPE5-DAG: public func split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [ArraySlice<String>]
+// TYPE5-DAG: public __consuming func prefix(_ maxLength: Int) -> ArraySlice<String>
+// TYPE5-DAG: public __consuming func suffix(_ maxLength: Int) -> ArraySlice<String>
+// TYPE5-DAG: public __consuming func split(separator: String, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [ArraySlice<String>]
 // TYPE5-DAG: public func formIndex(_ i: inout Int, offsetBy distance: Int)
 // TYPE5-DAG: public func distance(from start: Int, to end: Int) -> Int
 // TYPE5-DAG: public func joined(separator: String = "") -> String

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -reconstruct-type -source-filename %s | %FileCheck %s -implicit-check-not="FAILURE"
+// XFAIL: *
 
 struct Mystruct1 {
 // CHECK: decl: struct Mystruct1
@@ -64,7 +65,7 @@ class Myclass2 {
 
     arr1.append(1)
 // FIXME: missing append()
-// CHECK: dref: FAILURE	for 'append' usr=s:Sa6appendyyxF
+// CHECK: dref: FAILURE	for 'append' usr=s:Sa6appendyyxnF
 // CHECK: type: (inout Array<Int>) -> (Int) -> ()
 
     var arr2 : [Mystruct1]

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -90,10 +90,10 @@ func testIS1() -> Int { return 0 }
 let _: String = testIS1() // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
 
 func insertA<T>(array : inout [T], elt : T) {
-  array.append(T.self); // expected-error {{cannot invoke 'append' with an argument list of type '(T.Type)'}} expected-note {{expected an argument list of type '(T)'}}
+  array.append(T.self); // expected-error {{cannot invoke 'append' with an argument list of type '(T.Type)'}} expected-note {{expected an argument list of type '(__owned T)'}}
 
   // FIXME: Kind of weird
-  array.append(T); // expected-error {{cannot invoke 'append' with an argument list of type '((T).Type)'}} expected-note {{expected an argument list of type '(T)'}}
+  array.append(T); // expected-error {{cannot invoke 'append' with an argument list of type '((T).Type)'}} expected-note {{expected an argument list of type '(__owned T)'}}
 }
 
 // <rdar://problem/17875634> can't append to array of tuples

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -502,8 +502,8 @@ func accessOptionalArray(_ dict : MyDict<Int, [Int]>) {
 // ----- call Array.append
 // CHECK:   alloc_stack $Int
 // CHECK:   store %{{.*}} to [trivial]
-// CHECK:   function_ref @$SSa6appendyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout Array<τ_0_0>) -> ()
-// CHECK:   apply %{{.*}}<Int>(%{{.*}}, [[TEMPARRAYADR]]) : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout Array<τ_0_0>) -> ()
+// CHECK:   function_ref @$sSa6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+// CHECK:   apply %{{.*}}<Int>(%{{.*}}, [[TEMPARRAYADR]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
 // CHECK:   [[TEMPARRAYVAL:%.*]] = load [take] [[TEMPACCESS]] : $*Optional<Array<Int>>
 // CHECK:   [[ARRAYCOPY:%.*]] = alloc_stack $Optional<Array<Int>>
 // CHECK:   store [[TEMPARRAYVAL]] to [init] [[ARRAYCOPY]] : $*Optional<Array<Int>>

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -5,7 +5,7 @@
 
 // CHECK-LABEL: sil @{{.*}}testInt
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref @$SSa6appendyyxFSi_Tg5
+// CHECK:        [[F:%[0-9]+]] = function_ref @$sSa6appendyyxnFSi_Tg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NEXT:   tuple
@@ -19,7 +19,7 @@ public func testInt(_ a: inout [Int]) {
 // CHECK:        [[FR:%[0-9]+]] = function_ref @$SSa15reserveCapacityyySiFSi_Tg5
 // CHECK-NEXT:   apply [[FR]]
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref @$SSa6appendyyxFSi_Tg5
+// CHECK:        [[F:%[0-9]+]] = function_ref @$sSa6appendyyxnFSi_Tg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NEXT:   apply [[F]]
@@ -32,7 +32,7 @@ public func testThreeInts(_ a: inout [Int]) {
 
 // CHECK-LABEL: sil @{{.*}}testTooManyInts
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref  @$SSa6append10contentsOfyqd___t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
+// CHECK:        [[F:%[0-9]+]] = function_ref  @$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5Tf4gn_n
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NOT: apply
@@ -43,7 +43,7 @@ public func testTooManyInts(_ a: inout [Int]) {
 
 // CHECK-LABEL: sil @{{.*}}testString
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref @$SSa6appendyyxFSS_Tg5
+// CHECK:        [[F:%[0-9]+]] = function_ref @$sSa6appendyyxnFSS_Tg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NOT: apply

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -310,7 +310,7 @@ sil @unknown_use : $@convention(thin) () -> () {
 // CHECK-NEXT: [[ARR:%.*]] = apply [[ASFUN]]
 // CHECK-NEXT: [[OWNER:%.*]] = tuple_extract [[ARR]]{{.*}}, 0
 // CHECK-NOT:    apply [[ACFUN]]
-// CHECK:      [[AEFUN:%.*]] = function_ref @$SSa6appendyyxF
+// CHECK:      [[AEFUN:%.*]] = function_ref @$sSa6appendyyxnF
 // CHECK-NEXT: [[STACK:%.*]] = alloc_stack $MyInt
 // CHECK-NEXT: store %{{[0-9]+}} to [[STACK]]
 // CHECK-NEXT: apply [[AEFUN]]<MyInt>([[STACK]]
@@ -357,13 +357,12 @@ sil [_semantics "array.append_contentsOf"] @arrayAppendContentsOfHello : $@conve
 // CHECK:      strong_retain %1 : $Hello
 // CHECK-NEXT: store %1 to %{{[0-9]+}} : $*Hello
 // CHECK-NOT:     apply
-// CHECK:      [[AEFUN:%.*]] = function_ref @$SSa6appendyyxF
+// CHECK:      [[AEFUN:%.*]] = function_ref @$sSa6appendyyxnF
 // CHECK-NEXT: strong_retain %1 : $Hello
 // CHECK-NEXT: [[STACK:%.*]] = alloc_stack $Hello
 // CHECK-NEXT: store %1 to [[STACK]]
 // CHECK-NEXT: apply [[AEFUN]]<Hello>([[STACK]], %0)
 // CHECK-NEXT: dealloc_stack [[STACK]]
-// CHECK-NEXT: strong_release %1
 // CHECK-NEXT: release_value [[OWNER]]
 // CHECK-NEXT: return
 sil @append_contentsOf_class : $@convention(thin) (@inout Array<Hello>, @owned Hello) -> @owned Hello {

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -49,7 +49,7 @@ func foo3(a: Float, b: Bool) {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
 // CHECK-REPLACEMENT2: <Group>Collection/Array</Group>
-// CHECK-REPLACEMENT2: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:Si">Int</Type>)</Declaration>
+// CHECK-REPLACEMENT2: <Declaration>{{.*}}mutating func append(_ newElement: __owned <Type usr="s:Si">Int</Type>)</Declaration>
 
 // RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
@@ -58,7 +58,7 @@ func foo3(a: Float, b: Bool) {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>
-// CHECK-REPLACEMENT4: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:13cursor_stdlib2S1V">S1</Type>)</Declaration>
+// CHECK-REPLACEMENT4: <Declaration>{{.*}}mutating func append(_ newElement: __owned <Type usr="s:13cursor_stdlib2S1V">S1</Type>)</Declaration>
 
 // RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
 // CHECK-MODULE-GROUP1: MODULE GROUPS BEGIN


### PR DESCRIPTION
From apple/swift#19360

* Add consuming/owned annotations to Collection implementations

* Update SILOptimizer tests

* Fix access_marker_verify test

* XFAIL reconstruct_type_from_mangled_name
