### PR TITLE
[WIP] 32-bit platform support

### DIFF
--- a/stdlib/private/StdlibUnicodeUnittest/StdlibUnicodeUnittest.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/StdlibUnicodeUnittest.swift
@@ -45,14 +45,23 @@ extension String {
 }
 
 public struct NormalizationTest {
-  public var sourceUTF16: [UInt16]
-  public var source: [UInt8]
-  public var NFC: [UInt8]
-  public var NFD: [UInt8]
-  public var NFKC: [UInt8]
-  public var NFKD: [UInt8]
+  public let loc: SourceLoc
+  public let sourceUTF16: [UInt16]
+  public let source: [UInt8]
+  public let NFC: [UInt8]
+  public let NFD: [UInt8]
+  public let NFKC: [UInt8]
+  public let NFKD: [UInt8]
 
-  init(source: String, NFC: String, NFD: String, NFKC: String, NFKD: String) {
+  init(
+    loc: SourceLoc,
+    source: String,
+    NFC: String,
+    NFD: String,
+    NFKC: String,
+    NFKD: String
+  ) {
+    self.loc = loc
     self.sourceUTF16 = source.parseUTF16CodeUnits()
     self.source = source.parseUTF8CodeUnits()
     self.NFC = NFC.parseUTF8CodeUnits()
@@ -65,12 +74,15 @@ public struct NormalizationTest {
 public let normalizationTests: [NormalizationTest] = {
   var tests = [NormalizationTest]()
 
-  let fileURL = URL(fileURLWithPath: CommandLine.arguments[2])
+  let file = CommandLine.arguments[2]
+  let fileURL = URL(fileURLWithPath: file)
 
   //Bridged String grapheme breaking is sloooooow.
   let fileContents = try! String(contentsOf: fileURL) + ""
 
+  var lineNumber: UInt = 0
   for line in fileContents.split(separator: "\n") {
+    lineNumber += 1
     guard line.hasPrefix("#") == false else {
       continue
     }
@@ -85,9 +97,13 @@ public let normalizationTests: [NormalizationTest] = {
     }
 
     let columns = content.split(separator: ";").filter { $0 != " " }.map(String.init)
-    let test = NormalizationTest(source: columns[0],
-                        NFC: columns[1], NFD: columns[2],
-                        NFKC: columns[3], NFKD: columns[4])
+    let test = NormalizationTest(
+      loc: SourceLoc(file, lineNumber),
+      source: columns[0],
+      NFC: columns[1],
+      NFD: columns[2],
+      NFKC: columns[3],
+      NFKD: columns[4])
 
     tests.append(test)
   }

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -69,16 +69,12 @@ extension String.Index {
 
   @inlinable @inline(__always)
   internal init(encodedOffset: Int, transcodedOffset: Int) {
-#if arch(i386) || arch(arm)
-    unimplemented_utf8_32bit()
-#else
-    _sanityCheck(encodedOffset == encodedOffset & 0x0000_FFFF_FFFF_FFFF)
-    _sanityCheck((0...3) ~= transcodedOffset)
     let pos = UInt64(truncatingIfNeeded: encodedOffset)
     let trans = UInt64(truncatingIfNeeded: transcodedOffset)
+    _sanityCheck(pos == pos & 0x0000_FFFF_FFFF_FFFF)
+    _sanityCheck(trans <= 3)
 
     self.init((pos &<< 16) | (trans &<< 14))
-#endif
   }
 
   /// Creates a new index at the specified code unit offset.

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -86,6 +86,9 @@ extension _AbstractStringStorage {
 }
 #endif // _runtime(_ObjC)
 
+#if arch(i386) || arch(arm)
+private typealias Flags = _StringObject.Flags
+#endif
 private typealias CountAndFlags = _StringObject.CountAndFlags
 
 //
@@ -97,11 +100,36 @@ private typealias CountAndFlags = _StringObject.CountAndFlags
 @_fixed_layout
 @usableFromInline
 final internal class _StringStorage: _AbstractStringStorage {
+#if arch(i386) || arch(arm)
+  // The total allocated storage capacity. Note that this includes the required
+  // nul-terminator
+  @nonobjc
+  @usableFromInline
+  internal var _realCapacity: Int
+
+  @nonobjc
+  @usableFromInline
+  internal var _count: Int
+
+  @nonobjc
+  @usableFromInline
+  internal var _flags: _StringObject.Flags
+
+  @nonobjc
+  internal var _reserved: UInt16
+
+  @nonobjc
+  @inlinable
+  override internal var count: Int {
+    @inline(__always) get { return _count }
+    @inline(__always) set { _count = newValue }
+  }
+#else
   // The capacity of our allocation. Note that this includes the nul-terminator,
   // which is not available for overridding.
   @nonobjc
   @usableFromInline
-  internal var _realCapacityAndFlags: UInt
+  internal var _realCapacityAndFlags: UInt64
 
   @nonobjc
   @usableFromInline
@@ -113,6 +141,17 @@ final internal class _StringStorage: _AbstractStringStorage {
     @inline(__always) get { return _countAndFlags.count }
     @inline(__always) set { _countAndFlags.count = newValue }
   }
+
+  // The total allocated storage capacity. Note that this includes the required
+  // nul-terminator
+  @nonobjc
+  internal var _realCapacity: Int {
+    @inline(__always) get {
+      return Int(truncatingIfNeeded:
+        _realCapacityAndFlags & _StringObject.Nibbles.largeAddressMask)
+    }
+  }
+#endif
 
   @nonobjc
   override internal var asString: String {
@@ -139,9 +178,16 @@ final internal class _StringStorage: _AbstractStringStorage {
 // curve.
 private func determineCodeUnitCapacity(_ desiredCapacity: Int) -> Int {
 #if arch(i386) || arch(arm)
-    unimplemented_utf8_32bit()
+  // FIXME: Adapt to actual 32-bit allocator. For now, let's arrange things so
+  // that the instance size will be a multiple of 4.
+  let bias = Int(bitPattern: _StringObject.nativeBias)
+  let minimum = bias + desiredCapacity + 1
+  let size = (minimum + 3) & ~3
+  _sanityCheck(size % 4 == 0)
+  let capacity = size - bias
+  _sanityCheck(capacity > desiredCapacity)
+  return capacity
 #else
-
   // Bigger than _SmallString, and we need 1 extra for nul-terminator
   let minCap = 1 + Swift.max(desiredCapacity, _SmallString.capacity)
   _sanityCheck(minCap < 0x1_0000_0000_0000, "max 48-bit length")
@@ -151,7 +197,6 @@ private func determineCodeUnitCapacity(_ desiredCapacity: Int) -> Int {
   _sanityCheck(
     capacity > desiredCapacity && capacity % 8 == 0 && capacity % 16 != 0)
   return capacity
-
 #endif
 }
 
@@ -167,9 +212,15 @@ extension _StringStorage {
       _StringStorage.self,
       realCodeUnitCapacity._builtinWordValue, UInt8.self,
       1._builtinWordValue, Optional<_StringBreadcrumbs>.self)
-
-    storage._realCapacityAndFlags = UInt(bitPattern: realCodeUnitCapacity)
+#if arch(i386) || arch(arm)
+    storage._realCapacity = realCodeUnitCapacity
+    storage._count = countAndFlags.count
+    storage._flags = countAndFlags.flags
+#else
+    storage._realCapacityAndFlags =
+      UInt64(truncatingIfNeeded: realCodeUnitCapacity)
     storage._countAndFlags = countAndFlags
+#endif
 
     storage._breadcrumbsAddress.initialize(to: nil)
     storage.terminator.pointee = 0 // nul-terminated
@@ -199,7 +250,12 @@ extension _StringStorage {
     capacity: Int,
     isASCII: Bool
   ) -> _StringStorage {
+#if arch(i386) || arch(arm)
+    let flags = Flags(isASCII: isASCII)
+    let countAndFlags = CountAndFlags(count: bufPtr.count, flags: flags)
+#else
     let countAndFlags = CountAndFlags(count: bufPtr.count, isASCII: isASCII)
+#endif
     _sanityCheck(capacity >= bufPtr.count)
     let storage = _StringStorage.create(
       capacity: capacity, countAndFlags: countAndFlags)
@@ -258,14 +314,20 @@ extension _StringStorage {
   }
 
   @nonobjc
-  private var isASCII: Bool { return _countAndFlags.isASCII }
+  private var isASCII: Bool {
+#if arch(i386) || arch(arm)
+    return _flags.isASCII
+#else
+    return _countAndFlags.isASCII
+#endif
+  }
 
   @nonobjc
   // @opaque
   internal var _breadcrumbsAddress: UnsafeMutablePointer<_StringBreadcrumbs?> {
     let raw = Builtin.getTailAddr_Word(
       start._rawValue,
-      realCapacity._builtinWordValue,
+      _realCapacity._builtinWordValue,
       UInt8.self,
       Optional<_StringBreadcrumbs>.self)
     return UnsafeMutablePointer(raw)
@@ -275,15 +337,7 @@ extension _StringStorage {
   // required nul-terminator
   @nonobjc
   internal var capacity: Int {
-    return realCapacity &- 1
-  }
-
-  // The total capacity available for code units. Note that this excludes the
-  // required nul-terminator
-  @nonobjc
-  private var realCapacity: Int {
-    return Int(bitPattern:
-      _realCapacityAndFlags & _StringObject.Nibbles.largeAddressMask)
+    return _realCapacity &- 1
   }
 
   // The unused capacity available for appending. Note that this excludes the
@@ -302,7 +356,7 @@ extension _StringStorage {
   // nul-terminator
   @nonobjc
   internal var unusedCapacity: Int {
-    get { return realCapacity &- count &- 1 }
+    get { return _realCapacity &- count &- 1 }
   }
 
   #if !INTERNAL_CHECKS_ENABLED
@@ -315,10 +369,14 @@ extension _StringStorage {
     _sanityCheck(unusedCapacity >= 0)
     _sanityCheck(count <= capacity)
     _sanityCheck(rawSelf + Int(_StringObject.nativeBias) == rawStart)
-    _sanityCheck(self.realCapacity > self.count, "no room for nul-terminator")
+    _sanityCheck(self._realCapacity > self.count, "no room for nul-terminator")
     _sanityCheck(self.terminator.pointee == 0, "not nul terminated")
 
+#if arch(i386) || arch(arm)
+    _flags._invariantCheck()
+#else
     _countAndFlags._invariantCheck()
+#endif
     if isASCII {
       _sanityCheck(_allASCII(self.codeUnits))
     }
@@ -335,8 +393,13 @@ extension _StringStorage {
   @_effects(releasenone)
   @nonobjc
   private func _postRRCAdjust(newCount: Int, newIsASCII: Bool) {
+#if arch(i386) || arch(arm)
+    self._count = newCount
+    self._flags = Flags(isASCII: newIsASCII)
+#else
     self._countAndFlags = CountAndFlags(
       count: newCount, isASCII: newIsASCII)
+#endif
     self.terminator.pointee = 0
     _invariantCheck()
   }
@@ -381,8 +444,7 @@ extension _StringStorage {
 
   @nonobjc
   internal func clear() {
-    self._countAndFlags = CountAndFlags(count: 0, isASCII: true)
-    self.terminator.pointee = 0
+    _postRRCAdjust(newCount: 0, newIsASCII: true)
   }
 }
 
@@ -485,8 +547,24 @@ final internal class _SharedStringStorage: _AbstractStringStorage {
   @nonobjc
   internal var _start: UnsafePointer<UInt8>
 
+#if arch(i386) || arch(arm)
+  @nonobjc
+  internal var _count: Int
+
+  @nonobjc
+  internal var _flags: _StringObject.Flags
+
+  @inlinable
+  @nonobjc
+  internal var _countAndFlags: _StringObject.CountAndFlags {
+    @inline(__always) get {
+      return CountAndFlags(count: _count, flags: _flags)
+    }
+  }
+#else
   @nonobjc
   internal var _countAndFlags: _StringObject.CountAndFlags
+#endif
 
   @nonobjc
   internal var _breadcrumbs: _StringBreadcrumbs? = nil
@@ -495,7 +573,13 @@ final internal class _SharedStringStorage: _AbstractStringStorage {
   internal var start: UnsafePointer<UInt8> { return _start }
 
   @nonobjc
-  override internal var count: Int { return _countAndFlags.count }
+  override internal var count: Int {
+#if arch(i386) || arch(arm)
+    return _count
+#else
+    return _countAndFlags.count
+#endif
+  }
 
   @nonobjc
   internal init(
@@ -504,7 +588,12 @@ final internal class _SharedStringStorage: _AbstractStringStorage {
   ) {
     self._owner = nil
     self._start = ptr
+#if arch(i386) || arch(arm)
+    self._count = countAndFlags.count
+    self._flags = countAndFlags.flags
+#else
     self._countAndFlags = countAndFlags
+#endif
     super.init()
     self._invariantCheck()
   }

--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -1,10 +1,12 @@
 // RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
 // RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
 
+// We have a separate test for 64-bit architectures.
+// REQUIRES: PTRSIZE=32
 
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
 // CHECK-LABEL: test_ascii_scalar_scalar2
-// CHECK:  ret { i64, %swift.bridge* } { i64 25185, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 25185,
 public func test_ascii_scalar_scalar2() -> String {
   return "a" + "b"
 }
@@ -12,42 +14,53 @@ public func test_ascii_scalar_scalar2() -> String {
 
 // NOTE: 11125601.byteSwapped = 0x61 'a', 0xC3 0xA9 'é'
 // CHECK-LABEL: test_scalar_otherscalar
-// CHECK:  ret { i64, %swift.bridge* } { i64 11125601, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 11125601,
 public func test_scalar_otherscalar() -> String {
   return "a" + "é"
 }
 
 // NOTE: -8097488946593795999.byteSwapped = 0x61 'a', 0xF0 0x9F 0x95 0xb4 '🕴', ...
+// NOTE: -8097488946593795999 = 0x8f9ff0b4959ff061
+// NOTE: -1784680351 = 0x959ff061, -1885343564 = 0x8f9ff0b4
 // CHECK-LABEL: test_scalar_char
-// CHECK:  ret { i64, %swift.bridge* } { i64 -8097488946593795999, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 -1784680351, i32 -1885343564,
 public func test_scalar_char() -> String {
   return "a" + "🕴🏿"
 }
 
 // NOTE: 112585666577249.byteSwapped = 0x61 'a', 0xc3 0xa9 'é', 0x64 'd', 0x65 'e', 0x66 'f'
+// NOTE: 112585666577249 = 1688847201 + (26213 << 32)
 // CHECK-LABEL: test_strng_strng2
-// CHECK:  ret { i64, %swift.bridge* } { i64 112585666577249, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 1688847201, i32 26213,
 public func test_strng_strng2() -> String {
   return "aé" + "def"
 }
 
 // NOTE: 43 = code-unit length
 // CHECK-LABEL: test_scalar_strng
-// CHECK:  ret { i64, %swift.bridge* } { i64 43, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 43, i32 sub
 public func test_scalar_strng() -> String {
   return "a" + "👨🏿‍💼+🧙🏿‍♂️=🕴🏿"
 }
 
 // NOTE: 7450828190687388257.byteSwapped = 0x61 'a', 0x62 'b', 0x63 'c', 0x64 'd', 0xC3 0xA8 'è', 0x66 'f', 0x67 'g', ...
+// NOTE: 1684234849 = 0x64636261, 1734781123 = 0x6766a8c3
 // CHECK-LABEL test_strng_concat_smol
-// CHECK:  ret { i64, %swift.bridge* } { i64 7450828190687388257, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 1684234849, i32 1734781123,
 public func test_strng_concat_smol() -> String {
+  return "a" + "bc" + "dèf" + "gĥ"
+}
+
+// NOTE: 11 = code-unit length
+// CHECK-LABEL test_strng_concat_not_quite_smol
+// CHECK: insertvalue { i32, i32, i32 } { i32 11, i32 sub
+public func test_strng_concat_not_quite_smol() -> String {
   return "a" + "bc" + "dèf" + "ghī"
 }
 
 // NOTE: 23 = code-unit length
 // CHECK-LABEL test_strng_concat_large
-// CHECK:  ret { i64, %swift.bridge* } { i64 23, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+// CHECK: insertvalue { i32, i32, i32 } { i32 23, i32 sub
 public func test_strng_concat_large() -> String {
   return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"
 }

--- a/test/SILOptimizer/concat_string_literals.64.swift
+++ b/test/SILOptimizer/concat_string_literals.64.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
+
+// We have a separate test for 32-bit architectures.
+// REQUIRES: PTRSIZE=64
+
+// NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
+// CHECK-LABEL: test_ascii_scalar_scalar2
+// CHECK:  ret { i64, %swift.bridge* } { i64 25185, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+public func test_ascii_scalar_scalar2() -> String {
+  return "a" + "b"
+}
+
+
+// NOTE: 11125601.byteSwapped = 0x61 'a', 0xC3 0xA9 'é'
+// CHECK-LABEL: test_scalar_otherscalar
+// CHECK:  ret { i64, %swift.bridge* } { i64 11125601, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+public func test_scalar_otherscalar() -> String {
+  return "a" + "é"
+}
+
+// NOTE: -8097488946593795999.byteSwapped = 0x61 'a', 0xF0 0x9F 0x95 0xb4 '🕴', ...
+// CHECK-LABEL: test_scalar_char
+// CHECK:  ret { i64, %swift.bridge* } { i64 -8097488946593795999, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+public func test_scalar_char() -> String {
+  return "a" + "🕴🏿"
+}
+
+// NOTE: 112585666577249.byteSwapped = 0x61 'a', 0xc3 0xa9 'é', 0x64 'd', 0x65 'e', 0x66 'f'
+// CHECK-LABEL: test_strng_strng2
+// CHECK:  ret { i64, %swift.bridge* } { i64 112585666577249, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+public func test_strng_strng2() -> String {
+  return "aé" + "def"
+}
+
+// NOTE: 43 = code-unit length
+// CHECK-LABEL: test_scalar_strng
+// CHECK:  ret { i64, %swift.bridge* } { i64 43, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+public func test_scalar_strng() -> String {
+  return "a" + "👨🏿‍💼+🧙🏿‍♂️=🕴🏿"
+}
+
+// NOTE: 7450828190687388257.byteSwapped = 0x61 'a', 0x62 'b', 0x63 'c', 0x64 'd', 0xC3 0xA8 'è', 0x66 'f', 0x67 'g', ...
+// CHECK-LABEL test_strng_concat_smol
+// CHECK:  ret { i64, %swift.bridge* } { i64 7450828190687388257, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
+public func test_strng_concat_smol() -> String {
+  return "a" + "bc" + "dèf" + "ghī"
+}
+
+// NOTE: 23 = code-unit length
+// CHECK-LABEL test_strng_concat_large
+// CHECK:  ret { i64, %swift.bridge* } { i64 23, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
+public func test_strng_concat_large() -> String {
+  return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"
+}

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -149,7 +149,7 @@ CharacterTests.test("sizeof") {
   // <rdar://problem/16754935> MemoryLayout<Character>.size is 9, should be 8
 
   let size1 = MemoryLayout<Character>.size
-  expectTrue(size1 == 16)
+  expectTrue(size1 == MemoryLayout<String>.size)
 
   let a: Character = "a"
   let size2 = MemoryLayout.size(ofValue: a)

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -48,15 +48,12 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Character.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field name=_representation offset=0
-// CHECK-32-NEXT:         (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field name=smallUTF16 offset=0
-// CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
-// CHECK-32-NEXT:           (field name=large offset=0
-// CHECK-32-NEXT:            (reference kind=strong refcounting=native)))))))
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// CHECK-32-NEXT:       (field name=_str offset=0
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// (unstable implementation details omitted)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -40,7 +40,20 @@ reflect(object: obj)
 // CHECK-32: Type info:
 // CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=4092
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// CHECK-32-NEXT:       (field name=_guts offset=0
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// CHECK-32-NEXT:           (field name=_object offset=0
+// CHECK-32-NEXT:             (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// (unstable implementation details omitted)
+// CHECK-32:               (field name=_variant offset=4
+// CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
+// (unstable implementation details omitted)
+// CHECK-32:               (field name=_discriminator offset=9
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=128
+// (unstable implementation details omitted)
+// CHECK-32:               (field name=_flags offset=10
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -225,14 +225,10 @@ reflect(object: obj)
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254))))
 // CHECK-32-NEXT:   (field name=t02 offset=16
-// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field name=_representation offset=0
-// CHECK-32-NEXT:         (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field name=smallUTF16 offset=0
-// CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
-// CHECK-32-NEXT:           (field name=large offset=0
-// CHECK-32-NEXT:             (reference kind=strong refcounting=native))))))
-// CHECK-32-NEXT:   (field name=t03 offset=24
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
+// CHECK-32-NEXT:       (field name=_str offset=0
+// (unstable implementation details omitted)
+// CHECK-32:   (field name=t03 offset=28
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t04 offset=32
@@ -275,7 +271,7 @@ reflect(object: obj)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t16 offset=88
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=4092
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=128
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t17 offset=100
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0

--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -18,13 +18,25 @@ import Swift
 import StdlibUnittest
 import StdlibUnicodeUnittest
 
-private func expectEqualIterators(expected: [UInt8], others: [[UInt8]]) {
+private func expectEqualIterators(
+  label: String,
+  expected: [UInt8],
+  others: [String: [UInt8]],
+  _ message: @autoclosure () -> String = "",
+  showFrame: Bool = true,
+  stackTrace: SourceLocStack = SourceLocStack(),
+  file: String = #file,
+  line: UInt = #line
+) {
   let expectedString = String(decoding: expected, as: UTF8.self)
   let expectedCodeUnits = expectedString._nfcCodeUnits
-  
-  for other in others {
+  for (otherLabel, other) in others {
     let otherString = String(decoding: other, as: UTF8.self)
-    expectEqual(expectedCodeUnits, otherString._nfcCodeUnits)
+    expectEqual(
+      expectedCodeUnits,
+      otherString._nfcCodeUnits,
+      "\(label) vs \(otherLabel)",
+      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
   }
 }
 
@@ -32,13 +44,28 @@ var tests = TestSuite("StringNormalization")
 
 tests.test("StringNormalization/ConvertToNFC") {
   for test in normalizationTests {
-    expectEqualIterators(expected: test.NFC, others: [test.source, test.NFC, test.NFD])
+    expectEqualIterators(
+      label: "NFC",
+      expected: test.NFC,
+      others: [
+        "source": test.source,
+        "NFC": test.NFC,
+        "NFD": test.NFD
+      ],
+      stackTrace: SourceLocStack(test.loc))
   }
 }
 
 tests.test("StringNormalization/ConvertNFK*ToNFKC") {
   for test in normalizationTests {
-    expectEqualIterators(expected: test.NFKC, others: [test.NFKC, test.NFKD])
+    expectEqualIterators(
+      label: "NFKC",
+      expected: test.NFKC,
+      others: [
+        "NFKC": test.NFKC,
+        "NFKD": test.NFKD
+      ],
+      stackTrace: SourceLocStack(test.loc))
   }
 }
 

--- a/validation-test/stdlib/StringNormalization.swift
+++ b/validation-test/stdlib/StringNormalization.swift
@@ -42,7 +42,12 @@ private func expectEqualIterators(
 
 var tests = TestSuite("StringNormalization")
 
-tests.test("StringNormalization/ConvertToNFC") {
+tests.test("StringNormalization/ConvertToNFC")
+.skip(.custom({
+      if #available(macOS 10.14, iOS 12, watchOS 5, tvOS 12, *) { return false }
+      return true
+    }, reason: "NormalizationTest.txt requires Unicode 11"))
+.code {
   for test in normalizationTests {
     expectEqualIterators(
       label: "NFC",
@@ -56,7 +61,12 @@ tests.test("StringNormalization/ConvertToNFC") {
   }
 }
 
-tests.test("StringNormalization/ConvertNFK*ToNFKC") {
+tests.test("StringNormalization/ConvertNFK*ToNFKC")
+.skip(.custom({
+      if #available(macOS 10.14, iOS 12, watchOS 5, tvOS 12, *) { return false }
+      return true
+    }, reason: "NormalizationTest.txt requires Unicode 11"))
+.code {
   for test in normalizationTests {
     expectEqualIterators(
       label: "NFKC",


### PR DESCRIPTION
This isn't quite ready yet, but it's getting close. I think it's ready for review!

Pending regressions:

- ~~String literal concatenation isn't optimized away (32/64)~~ (FIXED -- I originally switched to `_loadPartialUnalignedUInt64LE` which defeated the optimization for some reason. Reverting to a custom loop fixed that.)
- ~~StringNormalization failures (32):~~
    ```
    FAIL: ["StringNormalization/ConvertToNFC", "StringNormalization/ConvertNFK*ToNFKC"]
    ```
    (FIXED: Normalization tests require Unicode 11, which isn't available on iOS 10, which is what 32-bit iOS simulator tests use.)